### PR TITLE
ELECTRON-730 (Add logic to fetch active network requests from the client to validate)

### DIFF
--- a/js/mainApiMgr.js
+++ b/js/mainApiMgr.js
@@ -152,8 +152,11 @@ electron.ipcMain.on(apiName, (event, arg) => {
             break;
         }
         case apiCmds.optimizeMemoryConsumption:
-            if (typeof arg.memory === 'object' && typeof arg.cpuUsage === 'object' && typeof arg.memory.workingSetSize === 'number') {
-                setPreloadMemoryInfo(arg.memory, arg.cpuUsage);
+            if (typeof arg.memory === 'object'
+                && typeof arg.cpuUsage === 'object'
+                && typeof arg.memory.workingSetSize === 'number'
+                && typeof arg.activeRequests === 'number') {
+                setPreloadMemoryInfo(arg.memory, arg.cpuUsage, arg.activeRequests);
             }
             break;
         case apiCmds.optimizeMemoryRegister:

--- a/js/preload/preloadMain.js
+++ b/js/preload/preloadMain.js
@@ -365,7 +365,19 @@ function createAPI() {
             if (typeof locale === 'string') {
                 throttledSetLocale(locale);
             }
-        }
+        },
+
+        /**
+         * Allows JS to register activeRequests that can be used by electron to
+         * get the active network request from the client
+         *
+         * @param activeRequests
+         */
+        registerActiveRequests: function (activeRequests) {
+            if (typeof activeRequests === 'function') {
+                local.activeRequests = activeRequests;
+            }
+        },
     };
 
     // add support for both ssf and SYM_API name-space.
@@ -518,10 +530,12 @@ function createAPI() {
         if (window.name === 'main') {
             const memory = process.getProcessMemoryInfo();
             const cpuUsage = process.getCPUUsage();
+            const activeRequests = local.activeRequests();
             local.ipcRenderer.send(apiName, {
                 cmd: apiCmds.optimizeMemoryConsumption,
-                memory: memory,
-                cpuUsage: cpuUsage
+                memory,
+                cpuUsage,
+                activeRequests,
             });
         }
     });


### PR DESCRIPTION
## Description
Add logic to fetch active network requests from the client to validate [ELECTRON-730](https://perzoinc.atlassian.net/browse/ELECTRON-730)

## Solution Approach
Fetch the active network requests from the client and refresh only if the value is 0

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SFE-Client-App | [R53](https://github.com/SymphonyOSF/SFE-Client-App/pull/11430)
SFE-Client-App | [sprint 18.18](https://github.com/SymphonyOSF/SFE-Client-App/pull/11431)
SFE-Client-App | [dev](https://github.com/SymphonyOSF/SFE-Client-App/pull/11432)


## QA Checklist
- [X] Unit-Tests
[ELECTRON-730 Test Result.pdf](https://github.com/symphonyoss/SymphonyElectron/files/2355985/ELECTRON-730.Test.Result.pdf)

- [] Automation-Tests