### PR TITLE
SDA-3287 Notification shouldn't be resizable on Windows

### DIFF
--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -14,7 +14,7 @@ import {
   NOTIFICATION_WINDOW_TITLE,
   NotificationActions,
 } from '../common/api-interface';
-import { isNodeEnv, isWindowsOS } from '../common/env';
+import { isNodeEnv } from '../common/env';
 import { logger } from '../common/logger';
 import NotificationHandler from './notification-handler';
 
@@ -606,7 +606,7 @@ class Notification extends NotificationHandler {
       height: CONTAINER_HEIGHT,
       alwaysOnTop: true,
       skipTaskbar: true,
-      resizable: isWindowsOS,
+      resizable: false,
       show: false,
       frame: false,
       transparent: true,


### PR DESCRIPTION
## Description
Prevent notifications to be resizable on Windows.

JIRA ticket: https://perzoinc.atlassian.net/browse/SDA-3287

Original JIRA ticket linked to this issue: https://perzoinc.atlassian.net/browse/SDA-2092
Original issue: https://github.com/electron/electron/issues/611
Fix on Electron: https://github.com/electron/electron/pull/29721
