### PR TITLE
SDA-3126 Stop reporting main process crashes

### DIFF
--- a/src/app/crash-handler.ts
+++ b/src/app/crash-handler.ts
@@ -63,18 +63,7 @@ class CrashHandler {
       logger.info(`crash-handler: No crashes found for main process`);
       return;
     }
-    const eventData: ICrashData = {
-      element: AnalyticsElements.SDA_CRASH,
-      process: SDACrashProcess.MAIN,
-      windowName: 'main',
-      crashCause: lastCrash.id,
-    };
-    analytics.track(eventData);
-    logger.info(
-      `crash-handler: Main process crash event processed with data ${JSON.stringify(
-        eventData,
-      )}`,
-    );
+    logger.info('crash-handler: Main process crashes found');
   }
 
   constructor() {

--- a/src/app/reports-handler.ts
+++ b/src/app/reports-handler.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { ILogs } from '../common/api-interface';
-import { isLinux, isMac } from '../common/env';
+import { isLinux, isMac, isWindowsOS } from '../common/env';
 import { i18n } from '../common/i18n';
 import { logger } from '../common/logger';
 
@@ -179,10 +179,8 @@ export const exportLogs = (): void => {
  */
 export const exportCrashDumps = (): void => {
   const FILE_EXTENSIONS = isMac ? ['.dmp'] : ['.dmp', '.txt'];
-  const crashesDirectory = app.getPath('crashDumps');
-  const source = isMac ? crashesDirectory + '/completed' : crashesDirectory;
+  const source = getCrashesDirectory();
   const focusedWindow = BrowserWindow.getFocusedWindow();
-
   if (
     !fs.existsSync(source) ||
     (fs.readdirSync(source).length === 0 &&
@@ -218,4 +216,15 @@ export const exportCrashDumps = (): void => {
         });
       }
     });
+};
+
+const getCrashesDirectory = (): string => {
+  const crashesDirectory = app.getPath('crashDumps');
+  let source = crashesDirectory;
+  if (isMac) {
+    source += '/completed';
+  } else if (isWindowsOS) {
+    source += '\\reports';
+  }
+  return source;
 };


### PR DESCRIPTION
## Description
As long as crash dumps folder contains a crash dump, ```getLastCrashReport``` function returns a crash report with useless data ( no date, no id). Consequently, each time we launch SDA, a new crash event is sent to our BI dashboard, reason why we have so many crashes reported that doesn't reflect the reality.
 
