### PR TITLE
SDA-3534 Centering SDA snipping tool

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1283,12 +1283,13 @@ export class WindowHandler {
           windowBounds.width !== toolWidth
         ) {
           logger.info(
-            'window-handler: Could not create window with correct size, resizing with setBounds',
+            'window-handler: Could not create window with correct size, resizing with setBounds and centering with center',
           );
           this.snippingToolWindow.setBounds({
             height: toolHeight,
             width: toolWidth,
           });
+          this.snippingToolWindow.center();
           logger.info(
             'window-handler: window bounds after resizing: ' +
               JSON.stringify(this.snippingToolWindow.getBounds()),


### PR DESCRIPTION
## Description
If we try to take a large screenshot using our custom snipping tool in a "Portrait" screen mode, preview wasn't well positioned, leading to a hidden "Done button".

## Preview

https://user-images.githubusercontent.com/51402489/148101981-05bfb3b7-0dad-4fb3-b981-fbbf2f3a2d04.mp4


