### PR TITLE
SDA-3489 (Bump electron spellcheck version to 2.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "electron-dl": "3.0.0",
     "electron-fetch": "1.4.0",
     "electron-log": "4.0.7",
-    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.2",
+    "electron-spellchecker": "git+https://github.com/symphonyoss/electron-spellchecker.git#v2.3.3",
     "ffi-napi": "3.0.0",
     "filesize": "6.1.0",
     "lazy-brush": "^1.0.1",


### PR DESCRIPTION
## Description
- Bump electron spellcheck version to 2.3.3
- This adds support for copying blob images to clipboard

## Related PRs
[electron-spellchecker](https://github.com/finos/electron-spellchecker/pull/11)
