### PR TITLE
SDA-3534 Snipping tool width shouldn't be greater than screen width and height

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1172,9 +1172,7 @@ export class WindowHandler {
     // Snipping tool height shouldn't be greater than min of screen width and height (screen orientation can be portrait or landscape)
     const minSize = Math.min(workAreaSize.width, workAreaSize.height);
     const maxToolHeight = Math.floor(calculatePercentage(minSize, 90));
-    const maxToolWidth = Math.floor(
-      calculatePercentage(workAreaSize.width, 90),
-    );
+    const maxToolWidth = Math.floor(calculatePercentage(minSize, 90));
     const availableAnnotateAreaHeight = maxToolHeight - BUTTON_BARS_HEIGHT;
     const availableAnnotateAreaWidth = maxToolWidth;
     const scaleFactor = display.scaleFactor;


### PR DESCRIPTION
## Description
Blocking snipping tool width to max of screen height and width to support screen rotation.
This PR complements https://github.com/finos/SymphonyElectron/pull/1324

## JIRA ticket
https://perzoinc.atlassian.net/browse/SDA-3534