### PR TITLE
SDA-3565 - Allow C2 / extensions to determine the presence of Citrix media redirection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14455,6 +14455,15 @@
         "rc": "^1.2.8"
       }
     },
+    "registry-js": {
+      "version": "1.15.1",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/registry-js/-/registry-js-1.15.1.tgz",
+      "integrity": "sha1-9Bwym/wkYbbCDhrqPwsuJrbWvdU=",
+      "requires": {
+        "node-addon-api": "^3.1.0",
+        "prebuild-install": "^5.3.5"
+      }
+    },
     "registry-url": {
       "version": "5.1.0",
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/registry-url/-/registry-url-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -171,6 +171,7 @@
     "react": "16.13.0",
     "react-dom": "16.13.0",
     "ref-napi": "1.4.3",
+    "registry-js": "^1.15.1",
     "rimraf": "^3.0.2",
     "save-svg-as-png": "^1.4.17",
     "shell-path": "2.1.0"

--- a/spec/citrixHandler.spec.ts
+++ b/spec/citrixHandler.spec.ts
@@ -1,5 +1,5 @@
 import { enumerateValues } from 'registry-js';
-import { getCitrixMediaRedirectionStatus } from '../src/app/citrix-handler';
+import { getCitrixMediaRedirectionStatus, RedirectionStatus } from '../src/app/citrix-handler';
 
 jest.mock('registry-js');
 
@@ -21,7 +21,7 @@ describe('citrix handler', () => {
       },
     ]);
     const status = getCitrixMediaRedirectionStatus();
-    expect(status).toBe('inactive');
+    expect(status).toBe(RedirectionStatus.INACTIVE);
   });
 
   it('status supported', () => {
@@ -33,7 +33,7 @@ describe('citrix handler', () => {
       },
     ]);
     const status = getCitrixMediaRedirectionStatus();
-    expect(status).toBe('supported');
+    expect(status).toBe(RedirectionStatus.SUPPORTED);
   });
 
   it('status unsupported', () => {
@@ -45,6 +45,6 @@ describe('citrix handler', () => {
       },
     ]);
     const status = getCitrixMediaRedirectionStatus();
-    expect(status).toBe('unsupported');
+    expect(status).toBe(RedirectionStatus.UNSUPPORTED);
   });
 });

--- a/spec/citrixHandler.spec.ts
+++ b/spec/citrixHandler.spec.ts
@@ -1,0 +1,50 @@
+import { enumerateValues } from 'registry-js';
+import { getCitrixMediaRedirectionStatus } from '../src/app/citrix-handler';
+
+jest.mock('registry-js');
+
+describe('citrix handler', () => {
+  const mockEnumerateValues = (enumerateValues as unknown) as jest.MockInstance<
+    typeof enumerateValues
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks().resetModules();
+  });
+
+  it('status inactive', () => {
+    mockEnumerateValues.mockReturnValue([
+      {
+        name: 'OtherValue',
+        type: 'REG_SZ',
+        data: 42,
+      },
+    ]);
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe('inactive');
+  });
+
+  it('status supported', () => {
+    mockEnumerateValues.mockReturnValue([
+      {
+        name: 'MSTeamsRedirectionSupport',
+        type: 'REG_DWORD',
+        data: 1,
+      },
+    ]);
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe('supported');
+  });
+
+  it('status unsupported', () => {
+    mockEnumerateValues.mockReturnValue([
+      {
+        name: 'MSTeamsRedirectionSupport',
+        type: 'REG_DWORD',
+        data: 0,
+      },
+    ]);
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe('unsupported');
+  });
+});

--- a/spec/citrixHandler.spec.ts
+++ b/spec/citrixHandler.spec.ts
@@ -3,6 +3,14 @@ import { getCitrixMediaRedirectionStatus, RedirectionStatus } from '../src/app/c
 
 jest.mock('registry-js');
 
+jest.mock('../src/common/env', () => {
+  return {
+    isWindowsOS: true,
+    isLinux: false,
+    isMac: false,
+  };
+});
+
 describe('citrix handler', () => {
   const mockEnumerateValues = (enumerateValues as unknown) as jest.MockInstance<
     typeof enumerateValues
@@ -46,5 +54,19 @@ describe('citrix handler', () => {
     ]);
     const status = getCitrixMediaRedirectionStatus();
     expect(status).toBe(RedirectionStatus.UNSUPPORTED);
+  });
+
+  it('non-windows os', () => {
+    jest.mock('../src/common/env', () => {
+      return {
+        isWindowsOS: false,
+        isLinux: true,
+        isMac: false,
+      };
+    });
+    const { getCitrixMediaRedirectionStatus, RedirectionStatus } = require('../src/app/citrix-handler');
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe(RedirectionStatus.INACTIVE);
+    expect(mockEnumerateValues).not.toHaveBeenCalled();
   });
 });

--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -1,4 +1,5 @@
 import { activityDetection } from '../src/app/activity-detection';
+import { getCitrixMediaRedirectionStatus } from '../src/app/citrix-handler';
 import { downloadHandler } from '../src/app/download-handler';
 import '../src/app/main-api-handler';
 import { protocolHandler } from '../src/app/protocol-handler';
@@ -125,6 +126,12 @@ jest.mock('../src/app/notifications/notification-helper', () => {
       showNotification: jest.fn(),
       closeNotification: jest.fn(),
     },
+  };
+});
+
+jest.mock('../src/app/citrix-handler', () => {
+  return {
+    getCitrixMediaRedirectionStatus: jest.fn(),
   };
 });
 
@@ -468,6 +475,14 @@ describe('main api handler', () => {
       };
       ipcMain.send(apiName.symphonyApi, value);
       expect(spy).toBeCalled();
+    });
+
+    it('should call `getCitrixMediaRedirectionStatus` correctly', () => {
+      const value = {
+        cmd: apiCmds.getCitrixMediaRedirectionStatus,
+      };
+      ipcMain.send(apiName.symphonyApi, value);
+      expect(getCitrixMediaRedirectionStatus).toBeCalled();
     });
   });
 });

--- a/src/app/citrix-handler.ts
+++ b/src/app/citrix-handler.ts
@@ -1,0 +1,23 @@
+import { enumerateValues, HKEY, RegistryValueType } from 'registry-js';
+
+export const getCitrixMediaRedirectionStatus = ():
+  | 'inactive'
+  | 'supported'
+  | 'unsupported' => {
+  const values = enumerateValues(
+    HKEY.HKEY_CURRENT_USER,
+    'Software\\Citrix\\HDXMediaStream',
+  );
+
+  for (const value of values) {
+    if (value.name === 'MSTeamsRedirectionSupport') {
+      if (value.type === RegistryValueType.REG_DWORD && value.data === 1) {
+        return 'supported';
+      } else {
+        return 'unsupported';
+      }
+    }
+  }
+
+  return 'inactive';
+};

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -18,6 +18,7 @@ import { activityDetection } from './activity-detection';
 import { analytics } from './analytics-handler';
 import appStateHandler from './app-state-handler';
 import { autoUpdate } from './auto-update-handler';
+import { getCitrixMediaRedirectionStatus } from './citrix-handler';
 import { CloudConfigDataTypes, config, ICloudConfig } from './config-handler';
 import { downloadHandler } from './download-handler';
 import { mainEvents } from './main-event-handler';
@@ -449,6 +450,8 @@ ipcMain.handle(
             : false;
         }
         break;
+      case apiCmds.getCitrixMediaRedirectionStatus:
+        return getCitrixMediaRedirectionStatus();
     }
     return;
   },

--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -61,6 +61,7 @@ export enum apiCmds {
   setBroadcastMessage = 'set-broadcast-message',
   handleSwiftSearchMessageEvents = 'handle-shift-search-message-events',
   onSwiftSearchMessage = 'on-shift-search-message',
+  getCitrixMediaRedirectionStatus = 'get-citrix-media-redirection-status',
 }
 
 export enum apiName {

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -276,6 +276,11 @@
     Full path to MSI <input type="text" id="update-file" />
     <br />
     <button id="run-update">Update</button>
+
+    <hr />
+    <p>Citrix Media Redirection Status:</p>
+    <button id="get-citrix-media-redir">Get status</button>
+    <input type="text" id="text-citrix-media-redir" />
     <hr />
     <br />
   </body>
@@ -323,6 +328,7 @@
       checkMediaPermission: 'check-media-permission',
       restartApp: 'restart-app',
       autoUpdate: 'auto-update',
+      getCitrixMediaRedirectionStatus: 'get-citrix-media-redirection-status',
     };
     let requestId = 0;
 
@@ -1176,5 +1182,22 @@
         postMessage(apiCmds.restartApp);
       }
     });
+
+    document
+      .getElementById('get-citrix-media-redir')
+      .addEventListener('click', () => {
+        const resultCallback = (status) => {
+          document.getElementById('text-citrix-media-redir').value = status;
+        };
+        if (window.ssf) {
+          window.ssf.getCitrixMediaRedirectionStatus().then(resultCallback);
+        } else if (window.manaSSF) {
+          window.manaSSF.getCitrixMediaRedirectionStatus().then(resultCallback);
+        } else {
+          postRequest(apiCmds.getCitrixMediaRedirectionStatus, null, {
+            successCallback: resultCallback,
+          });
+        }
+      });
   </script>
 </html>

--- a/src/renderer/preload-main.ts
+++ b/src/renderer/preload-main.ts
@@ -88,6 +88,8 @@ if (ssfWindow.ssf) {
     setZoomLevel: ssfWindow.ssf.setZoomLevel,
     getZoomLevel: ssfWindow.ssf.getZoomLevel,
     supportedSettings: ssfWindow.ssf.supportedSettings,
+    getCitrixMediaRedirectionStatus:
+      ssfWindow.ssf.getCitrixMediaRedirectionStatus,
   });
 }
 

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -5,6 +5,7 @@ import {
   searchAPIVersion,
   version,
 } from '../../package.json';
+import { RedirectionStatus } from '../app/citrix-handler';
 import { IDownloadItem } from '../app/download-handler';
 import {
   apiCmds,
@@ -735,9 +736,7 @@ export class SSFApi {
    * Retrieves the current status of Citrix' media redirection feature
    * @returns status
    */
-  public getCitrixMediaRedirectionStatus(): Promise<
-    'inactive' | 'supported' | 'unsupported'
-  > {
+  public getCitrixMediaRedirectionStatus(): Promise<RedirectionStatus> {
     return ipcRenderer.invoke(apiName.symphonyApi, {
       cmd: apiCmds.getCitrixMediaRedirectionStatus,
     });

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -730,6 +730,18 @@ export class SSFApi {
   public supportedSettings(): string[] {
     return SUPPORTED_SETTINGS || [];
   }
+
+  /**
+   * Retrieves the current status of Citrix' media redirection feature
+   * @returns status
+   */
+  public getCitrixMediaRedirectionStatus(): Promise<
+    'inactive' | 'supported' | 'unsupported'
+  > {
+    return ipcRenderer.invoke(apiName.symphonyApi, {
+      cmd: apiCmds.getCitrixMediaRedirectionStatus,
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

In order to support Citrix Media Optimization, it is necessary for an extension to be able to query the current status. Only when the redirection support is active is it necessary to proceed with loading and initializing the full Citrix client-side SDK.

## Related PRs
