### PR TITLE
SDA-3565 - Allow C2 / extensions to determine the presence of Citrix media redirection (v2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,6 +1974,12 @@
         "@types/node": "*"
       }
     },
+    "@vscode/windows-registry": {
+      "version": "1.0.5",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@vscode/windows-registry/-/windows-registry-1.0.5.tgz",
+      "integrity": "sha1-psRjrBI+57I/m5CTWuoIapeneNw=",
+      "optional": true
+    },
     "@wdio/config": {
       "version": "6.12.1",
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@wdio/config/-/config-6.12.1.tgz",

--- a/package.json
+++ b/package.json
@@ -176,6 +176,7 @@
     "shell-path": "2.1.0"
   },
   "optionalDependencies": {
+    "@vscode/windows-registry": "^1.0.5",
     "auto-update": "file:auto_update",
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#9.2.2",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.10",

--- a/spec/citrixHandler.spec.ts
+++ b/spec/citrixHandler.spec.ts
@@ -1,0 +1,64 @@
+import {
+  getCitrixMediaRedirectionStatus,
+  RedirectionStatus,
+} from '../src/app/citrix-handler';
+
+const mockGetStringRegKey = jest.fn();
+jest.mock(
+  '@vscode/windows-registry',
+  () => ({
+    GetStringRegKey: mockGetStringRegKey,
+  }),
+  { virtual: true },
+);
+
+jest.mock('../src/common/env', () => {
+  return {
+    isWindowsOS: true,
+    isLinux: false,
+    isMac: false,
+  };
+});
+
+describe('citrix handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks().resetModules();
+  });
+
+  it('status inactive', () => {
+    mockGetStringRegKey.mockImplementation(() => {
+      throw 'Key not found';
+    });
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe(RedirectionStatus.INACTIVE);
+  });
+
+  it('status supported', () => {
+    mockGetStringRegKey.mockReturnValue(String.fromCharCode(1));
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe(RedirectionStatus.SUPPORTED);
+  });
+
+  it('status unsupported', () => {
+    mockGetStringRegKey.mockReturnValue(String.fromCharCode(0));
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe(RedirectionStatus.UNSUPPORTED);
+  });
+
+  it('non-windows os', () => {
+    jest.mock('../src/common/env', () => {
+      return {
+        isWindowsOS: false,
+        isLinux: true,
+        isMac: false,
+      };
+    });
+    const {
+      getCitrixMediaRedirectionStatus,
+      RedirectionStatus,
+    } = require('../src/app/citrix-handler');
+    const status = getCitrixMediaRedirectionStatus();
+    expect(status).toBe(RedirectionStatus.INACTIVE);
+    expect(mockGetStringRegKey).not.toHaveBeenCalled();
+  });
+});

--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -1,4 +1,5 @@
 import { activityDetection } from '../src/app/activity-detection';
+import { getCitrixMediaRedirectionStatus } from '../src/app/citrix-handler';
 import { downloadHandler } from '../src/app/download-handler';
 import '../src/app/main-api-handler';
 import { protocolHandler } from '../src/app/protocol-handler';
@@ -125,6 +126,12 @@ jest.mock('../src/app/notifications/notification-helper', () => {
       showNotification: jest.fn(),
       closeNotification: jest.fn(),
     },
+  };
+});
+
+jest.mock('../src/app/citrix-handler', () => {
+  return {
+    getCitrixMediaRedirectionStatus: jest.fn(),
   };
 });
 
@@ -482,6 +489,14 @@ describe('main api handler', () => {
       };
       ipcMain.send(apiName.symphonyApi, value);
       expect(fromWebContentsMocked.getNativeWindowHandle).toBeCalledTimes(1);
+    });
+
+    it('should call `getCitrixMediaRedirectionStatus` correctly', () => {
+      const value = {
+        cmd: apiCmds.getCitrixMediaRedirectionStatus,
+      };
+      ipcMain.send(apiName.symphonyApi, value);
+      expect(getCitrixMediaRedirectionStatus).toBeCalled();
     });
   });
 });

--- a/src/app/citrix-handler.ts
+++ b/src/app/citrix-handler.ts
@@ -1,0 +1,46 @@
+import { isWindowsOS } from '../common/env';
+
+export enum RedirectionStatus {
+  /**
+   * Citrix virtual environment is not active
+   */
+  INACTIVE = 'inactive',
+
+  /**
+   * Citrix virtual environment is active and media redirection is supported
+   */
+  SUPPORTED = 'supported',
+
+  /**
+   * Citrix virtual environment is active but media redirection is not supported
+   */
+  UNSUPPORTED = 'unsupported',
+}
+
+export const getCitrixMediaRedirectionStatus = (): RedirectionStatus => {
+  if (!isWindowsOS) {
+    // Citrix virtual environments are not supported on non-Windows OSes
+    return RedirectionStatus.INACTIVE;
+  }
+
+  try {
+    const { GetStringRegKey } = require('@vscode/windows-registry');
+    const value = GetStringRegKey(
+      'HKEY_CURRENT_USER',
+      'Software\\Citrix\\HDXMediaStream',
+      'MSTeamsRedirectionSupport',
+    );
+    if (
+      value !== undefined &&
+      value.length === 1 &&
+      value.charCodeAt(0) === 1
+    ) {
+      return RedirectionStatus.SUPPORTED;
+    } else {
+      return RedirectionStatus.UNSUPPORTED;
+    }
+  } catch (e) {
+    // If the key does not exist, the function throws
+    return RedirectionStatus.INACTIVE;
+  }
+};

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -18,6 +18,7 @@ import { activityDetection } from './activity-detection';
 import { analytics } from './analytics-handler';
 import appStateHandler from './app-state-handler';
 import { autoUpdate } from './auto-update-handler';
+import { getCitrixMediaRedirectionStatus } from './citrix-handler';
 import { CloudConfigDataTypes, config, ICloudConfig } from './config-handler';
 import { downloadHandler } from './download-handler';
 import { mainEvents } from './main-event-handler';
@@ -457,6 +458,8 @@ ipcMain.handle(
           return browserWin.getNativeWindowHandle();
         }
         break;
+      case apiCmds.getCitrixMediaRedirectionStatus:
+        return getCitrixMediaRedirectionStatus();
     }
     return;
   },

--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -62,6 +62,7 @@ export enum apiCmds {
   handleSwiftSearchMessageEvents = 'handle-shift-search-message-events',
   onSwiftSearchMessage = 'on-shift-search-message',
   getNativeWindowHandle = 'get-native-window-handle',
+  getCitrixMediaRedirectionStatus = 'get-citrix-media-redirection-status',
 }
 
 export enum apiName {

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -283,6 +283,13 @@
     <input type="text" id="text-window-handle" />
     <hr />
     <br />
+
+    <hr />
+    <p>Citrix Media Redirection Status:</p>
+    <button id="get-citrix-media-redir">Get status</button>
+    <input type="text" id="text-citrix-media-redir" />
+    <hr />
+    <br />
   </body>
   <script>
     window.name = 'main';
@@ -329,6 +336,7 @@
       restartApp: 'restart-app',
       autoUpdate: 'auto-update',
       getNativeWindowHandle: 'get-native-window-handle',
+      getCitrixMediaRedirectionStatus: 'get-citrix-media-redirection-status',
     };
     let requestId = 0;
 
@@ -1198,6 +1206,23 @@
           window.manaSSF.getNativeWindowHandle().then(resultCallback);
         } else {
           postRequest(apiCmds.getNativeWindowHandle, null, {
+            successCallback: resultCallback,
+          });
+        }
+      });
+
+    document
+      .getElementById('get-citrix-media-redir')
+      .addEventListener('click', () => {
+        const resultCallback = (status) => {
+          document.getElementById('text-citrix-media-redir').value = status;
+        };
+        if (window.ssf) {
+          window.ssf.getCitrixMediaRedirectionStatus().then(resultCallback);
+        } else if (window.manaSSF) {
+          window.manaSSF.getCitrixMediaRedirectionStatus().then(resultCallback);
+        } else {
+          postRequest(apiCmds.getCitrixMediaRedirectionStatus, null, {
             successCallback: resultCallback,
           });
         }

--- a/src/renderer/preload-main.ts
+++ b/src/renderer/preload-main.ts
@@ -89,6 +89,8 @@ if (ssfWindow.ssf) {
     getZoomLevel: ssfWindow.ssf.getZoomLevel,
     supportedSettings: ssfWindow.ssf.supportedSettings,
     getNativeWindowHandle: ssfWindow.ssf.getNativeWindowHandle,
+    getCitrixMediaRedirectionStatus:
+      ssfWindow.ssf.getCitrixMediaRedirectionStatus,
   });
 }
 

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -5,6 +5,7 @@ import {
   searchAPIVersion,
   version,
 } from '../../package.json';
+import { RedirectionStatus } from '../app/citrix-handler';
 import { IDownloadItem } from '../app/download-handler';
 import {
   apiCmds,
@@ -738,6 +739,16 @@ export class SSFApi {
   public getNativeWindowHandle(): Promise<Buffer> {
     return ipcRenderer.invoke(apiName.symphonyApi, {
       cmd: apiCmds.getNativeWindowHandle,
+    });
+  }
+
+  /**
+   * Retrieves the current status of Citrix' media redirection feature
+   * @returns status
+   */
+  public getCitrixMediaRedirectionStatus(): Promise<RedirectionStatus> {
+    return ipcRenderer.invoke(apiName.symphonyApi, {
+      cmd: apiCmds.getCitrixMediaRedirectionStatus,
     });
   }
 }


### PR DESCRIPTION
## Description

In order to support Citrix Media Optimization, it is necessary for an extension to be able to query the current status. Only when the redirection support is active is it necessary to proceed with loading and initializing the full Citrix client-side SDK.

It depends on https://www.npmjs.com/package/@vscode/windows-registry which is also used in the VS Code editor, and which should be maintained for the foreseeable future. (This change has been implemented previously (#1331) using a different npm module for accessing the Windows registry, but it turned out that it contained problems).

## Related PRs

#1331 