### PR TITLE
SDA-3532 Snipping tool should remain on the top on Windows and MacOS

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1250,7 +1250,7 @@ export class WindowHandler {
       opts.alwaysOnTop = true;
     }
 
-    if (isWindowsOS && this.mainWindow) {
+    if (this.mainWindow) {
       opts.parent = this.mainWindow;
     }
 


### PR DESCRIPTION
## Description
Snipping tool should remain on the top on Windows and macOS