### PR TITLE
SDA-3525 Removing reply tooltip for notifications

### DIFF
--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -552,7 +552,6 @@ export default class NotificationComp extends React.Component<
         <button
           className={`action-button ${theming}`}
           style={{ display: hasReply ? 'block' : 'none' }}
-          title={i18n.t('Reply')()}
           onClick={this.eventHandlers.onOpenReply(id)}
         >
           {i18n.t('Reply')()}


### PR DESCRIPTION
## Description
No more "Reply" tooltip on toast notifications reply button.