### PR TITLE
SDA-3596 (Set the bounds for newly created child window)

### DIFF
--- a/src/app/child-window-handler.ts
+++ b/src/app/child-window-handler.ts
@@ -270,8 +270,16 @@ export const handleChildWindow = (webContents: WebContents): void => {
         ]);
         browserWin.setFullScreenable(true);
         browserWin.origin = contextOriginUrl || windowHandler.url;
-        if (isWindowsOS && browserWin && !browserWin.isDestroyed()) {
-          browserWin.setMenuBarVisibility(false);
+        if (browserWin && !browserWin.isDestroyed()) {
+          browserWin.setBounds({
+            x: newWinOptions.x,
+            y: newWinOptions.y,
+            width: newWinOptions.width,
+            height: newWinOptions.height,
+          });
+          if (isWindowsOS) {
+            browserWin.setMenuBarVisibility(false);
+          }
         }
       });
 


### PR DESCRIPTION
## Description
- Electron is no longer setting the bounds for the newly created child bounds
- Manually set the bounds for newly created child window on `start-loading`

## Related PRs
- [14.0.x](https://github.com/finos/SymphonyElectron/pull/1360)