### PR TITLE
SDA-3611 Support getting native window handles by window name

### DIFF
--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -58,6 +58,7 @@ jest.mock('../src/app/window-handler', () => {
 jest.mock('../src/app/window-utils', () => {
   return {
     downloadManagerAction: jest.fn(),
+    getWindowByName: jest.fn(),
     isValidWindow: jest.fn(() => true),
     sanitize: jest.fn(),
     setDataUrl: jest.fn(),
@@ -471,17 +472,35 @@ describe('main api handler', () => {
     });
 
     it('should call `getNativeWindowHandle` correctly', () => {
-      const fromWebContentsMocked = {
-        getNativeWindowHandle: jest.fn(),
+      const windows = {
+        main: {
+          getNativeWindowHandle: jest.fn(),
+        },
+        popout1: {
+          getNativeWindowHandle: jest.fn(),
+        },
+        popout2: {
+          getNativeWindowHandle: jest.fn(),
+        },
       };
-      jest.spyOn(BrowserWindow, 'fromWebContents').mockImplementation(() => {
-        return fromWebContentsMocked;
-      });
-      const value = {
+      jest
+        .spyOn(utils, 'getWindowByName')
+        .mockImplementation((windowName: string) => {
+          return windows[windowName];
+        });
+
+      ipcMain.send(apiName.symphonyApi, {
         cmd: apiCmds.getNativeWindowHandle,
-      };
-      ipcMain.send(apiName.symphonyApi, value);
-      expect(fromWebContentsMocked.getNativeWindowHandle).toBeCalledTimes(1);
+        windowName: 'main',
+      });
+      expect(windows['main'].getNativeWindowHandle).toBeCalledTimes(1);
+
+      ipcMain.send(apiName.symphonyApi, {
+        cmd: apiCmds.getNativeWindowHandle,
+        windowName: 'popout1',
+      });
+      expect(windows['popout1'].getNativeWindowHandle).toBeCalledTimes(1);
+      expect(windows['popout2'].getNativeWindowHandle).toBeCalledTimes(0);
     });
   });
 });

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -30,6 +30,7 @@ import { activate, handleKeyPress } from './window-actions';
 import { ICustomBrowserWindow, windowHandler } from './window-handler';
 import {
   downloadManagerAction,
+  getWindowByName,
   isValidView,
   isValidWindow,
   sanitize,
@@ -418,9 +419,7 @@ ipcMain.handle(
         }
         break;
       case apiCmds.getNativeWindowHandle:
-        const browserWin = BrowserWindow.fromWebContents(
-          event.sender,
-        ) as ICustomBrowserWindow;
+        const browserWin = getWindowByName(arg.windowName);
         if (browserWin && windowExists(browserWin)) {
           return browserWin.getNativeWindowHandle();
         }

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -279,7 +279,10 @@
 
     <hr />
     <p>Native Window Handle:</p>
-    <button id="get-window-handle">Get window handle</button>
+    <button id="get-window-handle">
+      Get window handle (optionally enter a window name)
+    </button>
+    <input type="text" id="text-window-handle-name" />
     <input type="text" id="text-window-handle" />
     <hr />
     <br />
@@ -1200,12 +1203,15 @@
             .join('');
           document.getElementById('text-window-handle').value = handleStr;
         };
+        const windowName = document.getElementById('text-window-handle-name')
+          .value;
         if (window.ssf) {
-          window.ssf.getNativeWindowHandle().then(resultCallback);
+          window.ssf.getNativeWindowHandle(windowName).then(resultCallback);
         } else if (window.manaSSF) {
-          window.manaSSF.getNativeWindowHandle().then(resultCallback);
+          window.manaSSF.getNativeWindowHandle(windowName).then(resultCallback);
         } else {
           postRequest(apiCmds.getNativeWindowHandle, null, {
+            windowName,
             successCallback: resultCallback,
           });
         }

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -737,12 +737,18 @@ export class SSFApi {
   }
 
   /**
-   * Get native window handle of the window where the renderer is displayed
+   * Get native window handle of the window, by default where the renderer is displayed,
+   * or optionally another window identified by its name.
+   * @param windowName optional window name, defaults to current renderer window
    * @returns the platform-specific handle of the window.
    */
-  public getNativeWindowHandle(): Promise<Buffer> {
+  public getNativeWindowHandle(windowName?: string): Promise<Buffer> {
+    if (!windowName) {
+      windowName = window.name || 'main';
+    }
     return ipcRenderer.invoke(apiName.symphonyApi, {
       cmd: apiCmds.getNativeWindowHandle,
+      windowName,
     });
   }
 


### PR DESCRIPTION
## Description

When calling the new (#1332) API to retrieve the native window handle from a renderer process, it is necessary to also be able to specify the window. This would allow code to also retrieve the window handle from child windows as they are used with the C2 Symphony client, where the SDA API is not available in child windows.
