### PR TITLE
SDA-3637  - (Remove remove spellchecker dependency from windows build scripts)

### DIFF
--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -113,26 +113,14 @@ class Script
                     new DirFiles(@"..\..\..\dist\win-unpacked\resources\*.*"),
                     new Dir(@"app.asar.unpacked",
                         new Dir(@"node_modules",
-                            new Dir(@"@felixrieseberg\spellchecker\build\Release",
-                                new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\@felixrieseberg\spellchecker\build\Release\spellchecker.node")
-                            ),
-                            new Dir(@"cld\build\Release",
-                                new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\cld\build\Release\cld.node")
-                            ),
                             new Dir(@"diskusage\build\Release",
                                 new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\diskusage\build\Release\diskusage.node")
                             ),
                             new Dir(@"ffi-napi\build\Release",
                                 new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\ffi-napi\build\Release\ffi_bindings.node")
                             ),
-                            new Dir(@"keyboard-layout\build\Release",
-                                new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\keyboard-layout\build\Release\keyboard-layout-manager.node")
-                            ),
                             new Dir(@"ref-napi\build\Release",
                                 new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\ref-napi\build\Release\binding.node")
-                            ),
-                            new Dir(@"spawn-rx",
-                                new Files(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\spawn-rx\*.*")
                             ),
                             new Dir(@"swift-search\node_modules",
                                 new Dir(@"ffi-napi\build\Release",

--- a/scripts/build-win64.bat
+++ b/scripts/build-win64.bat
@@ -106,12 +106,6 @@ if NOT EXIST %SIGNING_FILE_PATH% (
     exit /b -1
 )
 
-call %SIGNING_FILE_PATH% ..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\spawn-rx\vendor\jobber\Jobber.exe
-IF %errorlevel% neq 0 (
-	echo "Signing failed"
-	exit /b -1
-)
-
 call %SIGNING_FILE_PATH% ..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\screen-share-indicator-frame\ScreenShareIndicatorFrame.exe
 IF %errorlevel% neq 0 (
 	echo "Signing failed"


### PR DESCRIPTION
## Description
- Remove spellchecker dependency from Symphony.cs & build-win64.bat

## Related PRs
https://github.com/finos/SymphonyElectron/pull/1382
