### PR TITLE
SDA-3646 Screen sharing hack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4467,7 +4467,7 @@
       "dependencies": {
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "dev": true
         }
@@ -5277,7 +5277,7 @@
     },
     "css-value": {
       "version": "0.0.1",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/css-value/-/css-value-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/css-value/-/css-value-0.0.1.tgz",
       "integrity": "sha1-Xv1sLupeof1rasV+wEJ7GEUkJOo=",
       "dev": true
     },
@@ -5700,7 +5700,7 @@
     },
     "depd": {
       "version": "1.1.2",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/depd/-/depd-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
@@ -5764,7 +5764,7 @@
     },
     "dev-null": {
       "version": "0.1.1",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/dev-null/-/dev-null-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz",
       "integrity": "sha1-WiBc48Ky73e2I41roXnrdMag6Bg=",
       "dev": true
     },
@@ -6110,9 +6110,9 @@
       }
     },
     "electron": {
-      "version": "17.4.0",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-17.4.0.tgz",
-      "integrity": "sha1-mte2uskiQdrV6Ks+n2UvDtMRSFk=",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-17.4.1.tgz",
+      "integrity": "sha512-0qX+DbiNXlVSUxXq4lWVTis8QYqC4Q7R/Xkk3YZQbHMXZ90bWilypC3gBZAcN4MQD4AYUIebphBOpRPxlXY3nQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",
@@ -6121,9 +6121,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.12",
-          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@types/node/-/node-14.18.12.tgz",
-          "integrity": "sha1-DUVX/TuUSX15Pv1OfZLfL4O07yQ=",
+          "version": "14.18.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.13.tgz",
+          "integrity": "sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==",
           "dev": true
         }
       }
@@ -9691,7 +9691,7 @@
     },
     "humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
       "dev": true,
       "requires": {
@@ -10029,7 +10029,7 @@
     },
     "ip": {
       "version": "1.1.5",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/ip/-/ip-1.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
@@ -10275,7 +10275,7 @@
     },
     "is-lambda": {
       "version": "1.0.1",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/is-lambda/-/is-lambda-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=",
       "dev": true
     },
@@ -12023,7 +12023,7 @@
     },
     "lodash.isobject": {
       "version": "3.0.2",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
       "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
       "dev": true
     },
@@ -12075,7 +12075,7 @@
     },
     "lodash.zip": {
       "version": "4.2.0",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash.zip/-/lodash.zip-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
       "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
       "dev": true
     },
@@ -13039,19 +13039,19 @@
       "dependencies": {
         "tr46": {
           "version": "0.0.3",
-          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/tr46/-/tr46-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
           "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
           "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
-          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
           "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
           "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
-          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
           "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
           "dev": true,
           "requires": {
@@ -14566,7 +14566,7 @@
     },
     "promise-inflight": {
       "version": "1.0.1",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
@@ -15462,7 +15462,7 @@
       "dependencies": {
         "fast-deep-equal": {
           "version": "2.0.1",
-          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
           "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
           "dev": true
         }
@@ -15486,7 +15486,7 @@
     },
     "retry": {
       "version": "0.12.0",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/retry/-/retry-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "browserify": "16.5.1",
     "cross-env": "5.2.0",
     "del": "3.0.0",
-    "electron": "^17.4.0",
+    "electron": "^17.4.1",
     "electron-builder": "22.7.0",
     "electron-builder-squirrel-windows": "20.38.3",
     "electron-icon-maker": "0.0.4",


### PR DESCRIPTION
## Description
Closing the penultimate window activates the last window with Electron 17 on macOS.
As a consequence, when we try to screen share an app and click on "Share" button of the screen sharing screen picker, main application is brought to the front.
Here the proposal is the create a 0x0 transparent window before closing the screen sharing screen picker. This way, shared app remains at the front.
