### PR TITLE
SDA-3140 Certificates validation bugfix

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -667,11 +667,9 @@ export class WindowHandler {
     });
 
     // Certificate verification proxy
-    if (!isDevEnv) {
-      this.mainWebContents.session.setCertificateVerifyProc(
-        handleCertificateProxyVerification,
-      );
-    }
+    this.mainWebContents.session.setCertificateVerifyProc(
+      handleCertificateProxyVerification,
+    );
 
     app.on('browser-window-focus', () => {
       this.registerGlobalShortcuts();

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -682,8 +682,8 @@ export const handleCertificateProxyVerification = (
   ) {
     return callback(0);
   }
-
-  return callback(-2);
+  // We let chromium handle the verification result. In case chromium detects a certificate error, then 'certificate-error' event will be triggered.
+  return callback(-3);
 };
 
 /**


### PR DESCRIPTION
## Description
setCertificateVerifyProc sets the certificate verify proc.

There are 3 possible options:
- 0 - Indicates success and disables Certificate Transparency verification.
- -2 - Indicates failure.
- -3 - Uses the verification result from chromium.

Returning -3 let Chromium handle the result. In case the certificate is wrong (expired etc..) , `certificate-error` event is triggered.