### PR TITLE
SDA-3707 - Fix getting window handle for maximized windows

### DIFF
--- a/spec/hwndHandler.spec.ts
+++ b/spec/hwndHandler.spec.ts
@@ -67,35 +67,16 @@ describe('hwnd handler', () => {
     expect(hwnd).toBe(parent);
   });
 
-  it('no rect found for parent window', () => {
-    const parent = Buffer.from('validhwnd', 'utf8');
-    const hwnd = getContentWindowHandle(parent);
-    expect(hwnd).toBe(parent);
-  });
-
   it('no child window found', () => {
-    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
-      writeRect(rect, 10, 10, 100, 100);
-      return 1;
-    });
-
     const parent = Buffer.from('validhwnd', 'utf8');
     const hwnd = getContentWindowHandle(parent);
 
-    expect(mockGetWindowRect).toBeCalledTimes(1);
+    expect(mockGetWindowRect).toBeCalledTimes(0);
     expect(mockFindWindowExA).toBeCalledTimes(1);
     expect(hwnd).toBe(parent);
   });
 
-  it('matching child window found', () => {
-    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
-      writeRect(rect, 10, 10, 100, 100);
-      return 1;
-    });
-    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
-      writeRect(rect, 10, 20, 100, 100);
-      return 1;
-    });
+  it('no rect found for child window', () => {
     mockFindWindowExA.mockImplementationOnce(() => {
       return 4711;
     });
@@ -103,18 +84,58 @@ describe('hwnd handler', () => {
     const parent = Buffer.from('validhwnd', 'utf8');
     const hwnd = getContentWindowHandle(parent);
 
+    expect(mockGetWindowRect).toBeCalledTimes(1);
+    expect(mockFindWindowExA).toBeCalledTimes(2);
+    expect(hwnd).toBe(parent);
+  });
+
+  it('no rect found for second child window', () => {
+    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
+      writeRect(rect, 10, 10, 100, 10);
+      return 1;
+    });
+    mockFindWindowExA.mockImplementationOnce(() => {
+      return 4711;
+    });
+    mockFindWindowExA.mockImplementationOnce(() => {
+      return 42;
+    });
+
+    const parent = Buffer.from('validhwnd', 'utf8');
+    const hwnd = getContentWindowHandle(parent);
+
     expect(mockGetWindowRect).toBeCalledTimes(2);
-    expect(mockFindWindowExA).toBeCalledTimes(1);
+    expect(mockFindWindowExA).toBeCalledTimes(3);
+    expect(hwnd).toBe(parent);
+  });
+
+  it('matching child window found', () => {
+    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
+      writeRect(rect, 10, 20, 100, 100);
+      return 1;
+    });
+    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
+      writeRect(rect, 10, 10, 100, 10);
+      return 1;
+    });
+    mockFindWindowExA.mockImplementationOnce(() => {
+      return 4711;
+    });
+    mockFindWindowExA.mockImplementationOnce(() => {
+      return 42;
+    });
+
+    const parent = Buffer.from('validhwnd', 'utf8');
+    const hwnd = getContentWindowHandle(parent);
+
+    expect(mockGetWindowRect).toBeCalledTimes(2);
+    expect(mockFindWindowExA).toBeCalledTimes(3);
     expect(hwnd.readInt32LE(0)).toBe(4711);
   });
 
   it('matching child window found second', () => {
     mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
-      writeRect(rect, 10, 10, 100, 100);
-      return 1;
-    });
-    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
-      writeRect(rect, 100, 10, 100, 100);
+      writeRect(rect, 10, 10, 100, 10);
       return 1;
     });
     mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
@@ -131,16 +152,12 @@ describe('hwnd handler', () => {
     const parent = Buffer.from('validhwnd', 'utf8');
     const hwnd = getContentWindowHandle(parent);
 
-    expect(mockGetWindowRect).toBeCalledTimes(3);
-    expect(mockFindWindowExA).toBeCalledTimes(2);
+    expect(mockGetWindowRect).toBeCalledTimes(2);
+    expect(mockFindWindowExA).toBeCalledTimes(3);
     expect(hwnd.readInt32LE(0)).toBe(42);
   });
 
   it('no matching child window found', () => {
-    mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
-      writeRect(rect, 10, 10, 100, 100);
-      return 1;
-    });
     mockGetWindowRect.mockImplementationOnce((_hwnd, rect) => {
       writeRect(rect, 10, 10, 100, 100);
       return 1;
@@ -152,7 +169,7 @@ describe('hwnd handler', () => {
     const parent = Buffer.from('validhwnd', 'utf8');
     const hwnd = getContentWindowHandle(parent);
 
-    expect(mockGetWindowRect).toBeCalledTimes(2);
+    expect(mockGetWindowRect).toBeCalledTimes(1);
     expect(mockFindWindowExA).toBeCalledTimes(2);
     expect(hwnd).toBe(parent);
   });

--- a/src/app/hwnd-handler.ts
+++ b/src/app/hwnd-handler.ts
@@ -38,10 +38,8 @@ export const getContentWindowHandle = (nativeWindowHandle: Buffer): Buffer => {
   };
 
   const parentHwnd = nativeWindowHandle.readBigUInt64LE();
-  const parentRect = getWindowRect(parentHwnd);
-  if (!parentRect) {
-    return nativeWindowHandle;
-  }
+  const children = new Map();
+  let titleChild;
 
   let child = user32.FindWindowExA(
     parentHwnd.toString(),
@@ -51,13 +49,18 @@ export const getContentWindowHandle = (nativeWindowHandle: Buffer): Buffer => {
   );
   while (child !== 0) {
     const rect = getWindowRect(child);
+    if (rect) {
+      children.set(child, rect);
 
-    // The candidate child window is located at the same x position as the parent window, but
-    // has a higher y position (due to the window title frame at the top).
-    if (rect && parentRect.left === rect.left && parentRect.top < rect.top) {
-      const ret = Buffer.alloc(8);
-      ret.writeBigUInt64LE(BigInt(child));
-      return ret;
+      // The titlebar child is the one that is the least tall
+      if (!titleChild) {
+        titleChild = child;
+      } else {
+        const curTitleRect = children.get(titleChild)!;
+        if (rect.bottom - rect.top < curTitleRect.bottom - curTitleRect.top) {
+          titleChild = child;
+        }
+      }
     }
     child = user32.FindWindowExA(
       parentHwnd.toString(),
@@ -66,5 +69,15 @@ export const getContentWindowHandle = (nativeWindowHandle: Buffer): Buffer => {
       null,
     );
   }
+
+  // Return the first child window that isn't the title bar
+  for (const hwnd of children.keys()) {
+    if (hwnd !== titleChild) {
+      const ret = Buffer.alloc(8);
+      ret.writeBigUInt64LE(BigInt(hwnd));
+      return ret;
+    }
+  }
+
   return nativeWindowHandle;
 };


### PR DESCRIPTION
## Description

On Windows, the API to retrieve the native window handle selects the child window that Chrome uses to host the actual web content. If the window is maximized this unfortunately fails, as the parent window top coordinates may not be at (0,0) like the child is, but can be at something like (-8,-8) instead (depends on border decorations). This causes the RTC Citrix media optimization to position video overlays incorrectly in maximized windows.

To fix this we instead only look at the child windows. The one that is the least tall is the child window, so we can return any of the other ones. (Normally there is only one other candidate, but if developer tools are open there is a second one. They are however positioned identically so there's no need to choose a particular child in that case).
