### PR TITLE
SDA-3761 Prevent setting the menu on Windows for the whole app

### DIFF
--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -165,7 +165,6 @@ export class AppMenu {
   public buildMenu(): void {
     // updates the global variables
     this.updateGlobals();
-
     this.menuList = menuItemsArray.reduce(
       (map: Electron.MenuItemConstructorOptions, key: string) => {
         map[key] = this.buildMenuKey(key);
@@ -180,8 +179,6 @@ export class AppMenu {
 
     this.menu = Menu.buildFromTemplate(template);
     logger.info(`app-menu: built menu from the provided template`);
-    Menu.setApplicationMenu(this.menu);
-    logger.info(`app-menu: set application menu`);
 
     // Remove the default menu for window
     // as we use custom popup menu
@@ -190,6 +187,9 @@ export class AppMenu {
       if (mainWindow && windowExists(mainWindow)) {
         mainWindow.setMenuBarVisibility(false);
       }
+    } else {
+      logger.info(`app-menu: set application menu`);
+      Menu.setApplicationMenu(this.menu);
     }
   }
 

--- a/src/renderer/styles/about-app.less
+++ b/src/renderer/styles/about-app.less
@@ -1,9 +1,13 @@
-@import "theme";
+@import 'theme';
 
 @white: rgb(255, 255, 255, 1);
 @version-text-color: rgb(47, 47, 47, 1);
 @copyright-text-color: rgb(127, 127, 127, 1);
 @text-padding: 10px;
+
+::-webkit-scrollbar {
+  display: none;
+}
 
 body {
   background-color: white;
@@ -25,7 +29,6 @@ body {
 }
 
 .AboutApp:lang(fr-FR) {
-
   .AboutApp-symphony-section {
     padding-left: 10px;
   }
@@ -134,4 +137,3 @@ body {
     }
   }
 }
-


### PR DESCRIPTION
## Description
As of today, several API endpoints are calling `buildMenu` function.
This method was performing a `setApplicationMenu` which is supposed to set the menu at the top of each window on Windows.
In some specific edge-cases such as opening the 'About app' window before the web app has finished loading, we noticed that a menu was displayed where it shouldn't.
This PR aims at avoiding this behaviour on Windows. 
