### PR TITLE
SDA-3839 Resize SDA if unmaximizing

### DIFF
--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -333,9 +333,14 @@ ipcMain.on(
       case apiCmds.unmaximizeMainWindow:
         const mainWindow = windowHandler.getMainWindow();
         if (mainWindow && windowExists(mainWindow)) {
-          mainWindow.isFullScreen()
-            ? mainWindow.setFullScreen(false)
-            : mainWindow.unmaximize();
+          if (mainWindow.isFullScreen()) {
+            mainWindow.setFullScreen(false);
+          } else {
+            mainWindow.unmaximize();
+            setTimeout(() => {
+              windowHandler.forceUnmaximize();
+            }, 100);
+          }
         }
         // Give focus back to main webContents
         if (mainWebContents && !mainWebContents.isDestroyed()) {

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -2003,6 +2003,44 @@ export class WindowHandler {
   }
 
   /**
+   * Force app resizing while unmaximizing
+   * @returns void
+   */
+  public forceUnmaximize() {
+    if (this.titleBarView) {
+      {
+        if (
+          !this.mainView ||
+          !viewExists(this.mainView) ||
+          !this.mainWindow ||
+          !windowExists(this.mainWindow)
+        ) {
+          return;
+        }
+        const [width, height] = this.mainWindow?.getSize();
+        this.mainView.setBounds({
+          width,
+          height: height - TITLE_BAR_HEIGHT,
+          x: 0,
+          y: TITLE_BAR_HEIGHT,
+        });
+        this.titleBarView.setBounds({
+          width,
+          height: TITLE_BAR_HEIGHT,
+          x: 0,
+          y: 0,
+        });
+        mainEvents.publish('unmaximize');
+        // Workaround as electron does not resize devtools automatically
+        if (this.mainView.webContents.isDevToolsOpened()) {
+          this.mainView.webContents.toggleDevTools();
+          this.mainView.webContents.toggleDevTools();
+        }
+      }
+    }
+  }
+
+  /**
    * Listens for app load timeouts and reloads if required
    */
   private listenForLoad() {

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -1393,7 +1393,7 @@ export const loadBrowserViews = async (
   });
 
   windowHandler.setMainView(mainView);
-  windowHandler.setTitleBarView(mainView);
+  windowHandler.setTitleBarView(titleBarView);
 
   return mainView.webContents;
 };


### PR DESCRIPTION
## Description
`unmaximize` event is no more triggered on Electron v19. This regression has been introduced in Electron v18.4 (cannot reproduce on v18.3). As a consequence, `on('unmaximize')` function isn't triggered anymore.
As a work-around, we force app resizing if we need to unmaximize SDA.


