### PR TITLE
bugfix/SDA-3799 Avoid having multiple proxy basic auth modals open at the same time

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1538,6 +1538,10 @@ export class WindowHandler {
     clearSettings,
     callback,
   ): void {
+    if (this.basicAuthWindow && windowExists(this.basicAuthWindow)) {
+      this.basicAuthWindow.close();
+    }
+
     const opts = this.getWindowOpts(
       {
         width: 360,
@@ -1571,13 +1575,13 @@ export class WindowHandler {
         isValidCredentials: isMultipleTries,
       });
     });
+
     const closeBasicAuth = (_event, shouldClearSettings = true) => {
       if (shouldClearSettings) {
         clearSettings();
       }
       if (this.basicAuthWindow && windowExists(this.basicAuthWindow)) {
         this.basicAuthWindow.close();
-        this.basicAuthWindow = null;
       }
     };
 
@@ -1588,6 +1592,7 @@ export class WindowHandler {
     };
 
     this.basicAuthWindow.once('close', () => {
+      this.basicAuthWindow = null;
       ipcMain.removeListener('basic-auth-closed', closeBasicAuth);
       ipcMain.removeListener('basic-auth-login', login);
     });


### PR DESCRIPTION
## Description
SDA has a retry mechanism in case it fails loading target URL. If the retry mechanism happens while modal is open, the application receives a "login" event another time. Thus, we were having several modals created and we were losing control. Goal here is to unsure that we only have one single proxy auth modal at a time that correspond to latest proxy negotiation.
