### PR TITLE
Prevent from overriding global config if it's already done and parsed content is empty.

### DIFF
--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -722,9 +722,12 @@ class Config {
       }
       return;
     }
-    this.globalConfig = this.parseConfigData(
+    const parsedConfigData = this.parseConfigData(
       fs.readFileSync(this.globalConfigPath, 'utf8'),
     );
+    if (parsedConfigData && Object.keys(parsedConfigData).length > 0) {
+      this.globalConfig = parsedConfigData;
+    }
     logger.info(`config-handler: Global configuration: `, this.globalConfig);
   }
 


### PR DESCRIPTION
## Description
Backporting #1526 
