### PR TITLE
RTC-13524 Add notification ignore button

### DIFF
--- a/spec/notificationComp.spec.ts
+++ b/spec/notificationComp.spec.ts
@@ -129,6 +129,19 @@ describe('Toast notification component', () => {
     expect(toastNotificationReplyButton.exists()).toBeTruthy();
   });
 
+  it('should display ignore button when requested', () => {
+    const hasIgnore = true;
+    const ignoreButtonSelector = `.action-button`;
+    let toastNotificationIgnoreButton = wrapper.find(ignoreButtonSelector);
+    expect(toastNotificationIgnoreButton.exists()).toBeFalsy();
+    ipcRenderer.send(IPC_RENDERER_NOTIFICATION_DATA_CHANNEL, {
+      ...defaultProps,
+      hasIgnore,
+    });
+    toastNotificationIgnoreButton = wrapper.find(ignoreButtonSelector);
+    expect(toastNotificationIgnoreButton.exists()).toBeTruthy();
+  });
+
   it('should trigger mouse hovering function while hovering a notification', async () => {
     const spy = jest.spyOn(ipcRenderer, 'send');
     const notificationContainer = wrapper.find(

--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -185,6 +185,7 @@ export interface INotificationData {
   theme: Theme;
   isElectronNotification?: boolean;
   callback?: () => void;
+  hasIgnore?: boolean;
   hasReply?: boolean;
   hasMention?: boolean;
 }
@@ -192,6 +193,7 @@ export interface INotificationData {
 export enum NotificationActions {
   notificationClicked = 'notification-clicked',
   notificationClosed = 'notification-closed',
+  notificationIgnore = 'notification-ignore',
   notificationReply = 'notification-reply',
 }
 

--- a/src/renderer/components/notification-comp.tsx
+++ b/src/renderer/components/notification-comp.tsx
@@ -47,6 +47,7 @@ interface INotificationState {
   flash: boolean;
   isExternal: boolean;
   theme: Theme;
+  hasIgnore: boolean;
   hasReply: boolean;
   hasMention: boolean;
   isInputHidden: boolean;
@@ -74,6 +75,7 @@ export default class NotificationComp extends React.Component<
       this.close(_event, winKey),
     onClick: (data) => (_event: mouseEventButton) => this.click(data),
     onContextMenu: (event) => this.contextMenu(event),
+    onIgnore: (winKey) => (_event: mouseEventButton) => this.onIgnore(winKey),
     onMouseEnter: (winKey) => (_event: mouseEventButton) =>
       this.onMouseEnter(winKey),
     onMouseLeave: (winKey) => (_event: mouseEventButton) =>
@@ -100,6 +102,7 @@ export default class NotificationComp extends React.Component<
       isExternal: false,
       theme: '',
       isInputHidden: true,
+      hasIgnore: false,
       hasReply: false,
       hasMention: false,
       containerHeight: CONTAINER_HEIGHT,
@@ -193,6 +196,7 @@ export default class NotificationComp extends React.Component<
                 {this.renderExtBadge(isExternal)}
               </div>
               {this.renderReplyButton(id, themeClassName)}
+              {this.renderIgnoreButton(id, themeClassName)}
             </div>
             <span className={`message-preview ${themeClassName}`}>{body}</span>
           </div>
@@ -372,6 +376,15 @@ export default class NotificationComp extends React.Component<
       replyText = replyText.replace(/👍/g, ':thumbsup: ');
       ipcRenderer.send('notification-on-reply', id, replyText);
     }
+  }
+
+  /**
+   * Handles ignore action
+   * @param id
+   * @private
+   */
+  private onIgnore(id: number): void {
+    ipcRenderer.send('notification-on-ignore', id);
   }
 
   /**
@@ -555,6 +568,29 @@ export default class NotificationComp extends React.Component<
           onClick={this.eventHandlers.onOpenReply(id)}
         >
           {i18n.t('Reply')()}
+        </button>
+      );
+    }
+    return;
+  }
+
+  /**
+   * Renders ignore button
+   * @param id
+   * @param theming
+   */
+  private renderIgnoreButton(
+    id: number,
+    theming: string,
+  ): JSX.Element | undefined {
+    if (this.state.hasIgnore) {
+      return (
+        <button
+          className={`action-button ${theming}`}
+          style={{ display: 'block' }}
+          onClick={this.eventHandlers.onIgnore(id)}
+        >
+          {i18n.t('Ignore')()}
         </button>
       );
     }

--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -108,6 +108,9 @@ class Notification extends NotificationHandler {
     ipcMain.on('notification-on-reply', (_event, windowId, replyText) => {
       this.onNotificationReply(windowId, replyText);
     });
+    ipcMain.on('notification-on-ignore', (_event, windowId) =>
+      this.onNotificationIgnore(windowId),
+    );
     ipcMain.on('show-reply', this.funcHandlers.onShowReply);
     // Update latest notification settings from config
     app.on('ready', () => this.updateNotificationSettings());
@@ -272,6 +275,7 @@ class Notification extends NotificationHandler {
       flash,
       isExternal,
       theme,
+      hasIgnore,
       hasReply,
       hasMention,
     } = data;
@@ -286,6 +290,7 @@ class Notification extends NotificationHandler {
       flash,
       isExternal,
       theme,
+      hasIgnore,
       hasReply,
       hasMention,
     });
@@ -393,6 +398,26 @@ class Notification extends NotificationHandler {
         callback(NotificationActions.notificationReply, data, replyText);
       }
       this.notificationClosed(clientId);
+      this.hideNotification(clientId);
+    }
+  }
+
+  /**
+   * Handles notification ignore action
+   * @param clientId {number}
+   */
+  public onNotificationIgnore(clientId: number): void {
+    const browserWindow = this.getNotificationWindow(clientId);
+    if (
+      browserWindow &&
+      windowExists(browserWindow) &&
+      browserWindow.notificationData
+    ) {
+      const data = browserWindow.notificationData;
+      const callback = this.notificationCallbacks[clientId];
+      if (typeof callback === 'function') {
+        callback(NotificationActions.notificationIgnore, data);
+      }
       this.hideNotification(clientId);
     }
   }


### PR DESCRIPTION
## Description

For Symphony-C9 extension we need to be able to ignore an incoming call from a notification.
These changes will display an `Ignore` button on notifications when a new `hasIgnore: true` notification parameter is added.
A click on this button will trigger a `notification-ignore` event.
This is very similar to the existing notification `Reply` button.