### PR TITLE
SDA-3954 Avoid terminating C9Shell.exe during install

### DIFF
--- a/installer/win/WixSharpInstaller/CloseDialog.cs
+++ b/installer/win/WixSharpInstaller/CloseDialog.cs
@@ -13,7 +13,7 @@ namespace Symphony
         void dialog_Load(object sender, System.EventArgs e)
         {
             // Detect if Symphony is running
-            bool isRunning = (System.Diagnostics.Process.GetProcessesByName("Symphony").Length > 1 || System.Diagnostics.Process.GetProcessesByName("C9Shell").Length >= 1);
+            bool isRunning = System.Diagnostics.Process.GetProcessesByName("Symphony").Length > 1;
             if (isRunning)
             {
                 // If it is running, disable the "next" button

--- a/installer/win/WixSharpInstaller/MaintenanceDialog.cs
+++ b/installer/win/WixSharpInstaller/MaintenanceDialog.cs
@@ -12,7 +12,7 @@ namespace Symphony
         private void MaintenanceDialog_Shown(object sender, System.EventArgs e)
         {
             // Detect if Symphony is running
-            bool isRunning = (System.Diagnostics.Process.GetProcessesByName("Symphony").Length > 1 || System.Diagnostics.Process.GetProcessesByName("C9Shell").Length >= 1);
+            bool isRunning = System.Diagnostics.Process.GetProcessesByName("Symphony").Length > 1;
             if (isRunning)
             {
                 // If it is running, continue to the "Close Symphony" screen

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -109,7 +109,7 @@ class Script
             // will not work for us, as we have a "minimize on close" option, which stops the app from terminating on WM_CLOSE. So we
             // instruct the installer to not send a Close message, but instead send the EndSession message, and we have a custom event
             // handler in the SDA code which listens for this message, and ensures app termination when it is received.
-            new CloseApplication("Symphony.exe", false) { EndSessionMessage = true },
+            new CloseApplication("Symphony.exe", false) { EndSessionMessage = true }
             );
 
         // The build script which calls the wix# builder, will be run from a command environment which has %SYMVER% set.

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -110,7 +110,6 @@ class Script
             // instruct the installer to not send a Close message, but instead send the EndSession message, and we have a custom event
             // handler in the SDA code which listens for this message, and ensures app termination when it is received.
             new CloseApplication("Symphony.exe", false) { EndSessionMessage = true },
-            new CloseApplication("C9Shell.exe", false) { EndSessionMessage = true }
             );
 
         // The build script which calls the wix# builder, will be run from a command environment which has %SYMVER% set.
@@ -281,19 +280,6 @@ class Script
                 System.Diagnostics.Process.GetProcessesByName("Symphony").ForEach(p =>
                 {
                     if (System.IO.Path.GetFileName(p.MainModule.FileName) == "Symphony.exe")
-                    {
-                        if (!p.HasExited)
-                        {
-                            p.Kill();
-                            p.WaitForExit();
-                        }
-                    }
-                });
-
-                // The embedded C9 Shell should terminate when the parent window is closed, but it doesn't always work. So we'll just force it to exit
-                System.Diagnostics.Process.GetProcessesByName("C9Shell").ForEach(p =>
-                {
-                    if (System.IO.Path.GetFileName(p.MainModule.FileName) == "C9Shell.exe")
                     {
                         if (!p.HasExited)
                         {


### PR DESCRIPTION
## Description

Currently the installer tries to terminate any running C9Shell processes during installation, to avoid problems with open files that cannot be overwritten. However, as these processes may not actually be related to Symphony, this is not safe.

## Related PRs

This reverts the installer changes from #1446 