### PR TITLE
SDA-3958: Fix crash app on close

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1270,7 +1270,7 @@ export class WindowHandler {
         );
       }
     });
-    this.snippingToolWindow.once('closed', () => {
+    this.snippingToolWindow.once('close', () => {
       logger.info(
         'window-handler, createSnippingToolWindow: Closing snipping window, attempting to delete temp snip image',
       );


### PR DESCRIPTION
## Description
Pressing native windows close will automatically crash the app for temporary. Fixed

## Related PRs
