### PR TITLE
SDA-3976: Add few bugs fixed

### DIFF
--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -398,23 +398,33 @@ describe('main api handler', () => {
 
     it('should call `openScreenSnippet` correctly', () => {
       const spy = jest.spyOn(screenSnippet, 'capture');
+      jest.spyOn(BrowserWindow, 'getFocusedWindow').mockImplementation(() => {
+        return {
+          winName: 'main',
+        };
+      });
       const value = {
         cmd: apiCmds.openScreenSnippet,
       };
       const expectedValue = { send: expect.any(Function) };
       ipcMain.send(apiName.symphonyApi, value);
-      expect(spy).toBeCalledWith(expectedValue, undefined);
+      expect(spy).toBeCalledWith(expectedValue, 'main', undefined);
     });
 
     it('should call `openScreenSnippet` with hideOnCapture correctly', () => {
       const spy = jest.spyOn(screenSnippet, 'capture');
+      jest.spyOn(BrowserWindow, 'getFocusedWindow').mockImplementation(() => {
+        return {
+          winName: 'main',
+        };
+      });
       const value = {
         cmd: apiCmds.openScreenSnippet,
         hideOnCapture: true,
       };
       const expectedValue = { send: expect.any(Function) };
       ipcMain.send(apiName.symphonyApi, value);
-      expect(spy).toBeCalledWith(expectedValue, true);
+      expect(spy).toBeCalledWith(expectedValue, 'main', true);
     });
 
     it('should call `closeWindow` correctly', () => {

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -91,6 +91,7 @@ ipcMain.on(
       return;
     }
     const mainWebContents = windowHandler.getMainWebContents();
+    const currentWindow = BrowserWindow.getFocusedWindow();
     logApiCallParams(arg);
     switch (arg.cmd) {
       case apiCmds.isOnline:
@@ -203,7 +204,11 @@ ipcMain.on(
         }
         break;
       case apiCmds.openScreenSnippet:
-        screenSnippet.capture(event.sender, arg.hideOnCapture);
+        screenSnippet.capture(
+          event.sender,
+          (currentWindow as ICustomBrowserWindow)?.winName,
+          arg.hideOnCapture,
+        );
         break;
       case apiCmds.closeScreenSnippet:
         screenSnippet.cancelCapture();

--- a/src/renderer/styles/snipping-tool.less
+++ b/src/renderer/styles/snipping-tool.less
@@ -142,7 +142,7 @@ body.using-mouse :focus {
       background-color: @electricity-ui-40;
     }
 
-    .add-to-chat-button:focus {
+    .add-to-chat-button:active {
       background-color: @electricity-ui-60;
     }
 
@@ -220,7 +220,7 @@ body.using-mouse :focus {
   background: @electricity-ui-40;
 }
 
-.menu-button:focus {
+.menu-button:active {
   background: @electricity-ui-60;
 }
 


### PR DESCRIPTION
## Description
- Button click will no longer keeps its previous state after click and hold and drag out then mouse up
- Popout will always be at front after screen capture windows is close (this includes add to chat)
- Default folder to save will now be located at Downloads
- Api to hide SDA will not apply for both main and popout, whenever user capture, SDA (including popout will all be hidden) then right after restoring SDA (Close, add to chat, save as), the previously focused windows will be brought to front.


## Related PRs
