### PR TITLE
SDA-3987: Chevron SVG will no longer be draggable

### DIFF
--- a/spec/__snapshots__/menu-button.spec.tsx.snap
+++ b/spec/__snapshots__/menu-button.spec.tsx.snap
@@ -12,6 +12,7 @@ exports[`Menu Button should show all elements 1`] = `
     >
       <img
         alt="Open menu"
+        draggable={false}
         src="../renderer/assets/single-chevron-down.svg"
         title="Open menu"
       />

--- a/src/renderer/components/menu-button.tsx
+++ b/src/renderer/components/menu-button.tsx
@@ -103,6 +103,7 @@ const MenuButton: React.FunctionComponent<IMenuButtonProps> = ({
             src={`../renderer/assets/single-chevron-down.svg`}
             title={i18n.t('Open menu')()}
             alt={i18n.t('Open menu')()}
+            draggable={false}
           />
         </button>
         {isDisplay && (


### PR DESCRIPTION
## Description
Add a fix that forbid drag n drop on SVG Icon
## Related PRs
