### PR TITLE
SDA-3998 Improve logging for API call parameters related to apiCmds.writeCloud9Pipe

### DIFF
--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -551,6 +551,19 @@ const logApiCallParams = (arg: any) => {
         )}`,
       );
       break;
+    case apiCmds.writeCloud9Pipe:
+      const compressedData = {
+        ...arg,
+        data: Buffer.from(arg.data).toString('base64'),
+      };
+      logger.info(
+        `main-api-handler: - ${apiCmd} - Properties: ${JSON.stringify(
+          compressedData,
+          null,
+          2,
+        )}`,
+      );
+      break;
     default:
       logger.info(
         `main-api-handler: - ${apiCmd} - Properties: ${JSON.stringify(


### PR DESCRIPTION
## Description

The data field for these messages contain an Uint8Array which causes very verbose log messages (one line per byte). The logs are much more readable if they are on a single line in a more efficient encoding such as base64.
