### PR TITLE
Update symphony-c9-shell to 3.19.0-0.98.4.129

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "typescript": "3.9.10"
       },
       "optionalDependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.3.124",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.4.129",
         "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.13",
         "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#9.2.2",
         "winreg": "^1.2.4"
@@ -2666,9 +2666,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.3.124",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.3.124.tgz",
-      "integrity": "sha1-ZbMsRLfuc7s2zs1Pqw0vlTePDWY=",
+      "version": "3.19.0-0.98.4.129",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.4.129.tgz",
+      "integrity": "sha1-XApIPCrTfca2NIbKSR/PEpBgEAE=",
       "license": "UNLICENSED",
       "optional": true,
       "os": [
@@ -22723,9 +22723,9 @@
       "dev": true
     },
     "@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.3.124",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.3.124.tgz",
-      "integrity": "sha1-ZbMsRLfuc7s2zs1Pqw0vlTePDWY=",
+      "version": "3.19.0-0.98.4.129",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.4.129.tgz",
+      "integrity": "sha1-XApIPCrTfca2NIbKSR/PEpBgEAE=",
       "optional": true
     },
     "@szmarczak/http-timer": {

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "win32-api": "^20.1.0"
   },
   "optionalDependencies": {
-    "@symphony/symphony-c9-shell": "3.19.0-0.98.3.124",
+    "@symphony/symphony-c9-shell": "3.19.0-0.98.4.129",
     "screen-share-indicator-frame": "git+https://github.com/symphonyoss/ScreenShareIndicatorFrame.git#v1.4.13",
     "screen-snippet": "git+https://github.com/symphonyoss/ScreenSnippet2.git#9.2.2",
     "winreg": "^1.2.4"


### PR DESCRIPTION
## Description

Update the symphony-c9-shell optional dependency to 3.19.0-0.98.4.129 for the 23.1.x branch.

## Related PRs
