### PR TITLE
SDA-3971 HWND retriever helper for Windows

### DIFF
--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -66,6 +66,7 @@ class Script
                 new File(@"..\..\..\dist\win-unpacked\vulkan-1.dll"),
                 new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\screen-share-indicator-frame\ScreenShareIndicatorFrame.exe"),
                 new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\screen-snippet\ScreenSnippet.exe"),
+                new File(@"..\..\..\dist\win-unpacked\resources\app.asar.unpacked\node_modules\symphony-native-window-handle-helper\SymphonyNativeWindowHandleHelper.exe"),
                 new Dir(@"config",
                     new Files(@"..\..\..\dist\win-unpacked\config\*.*")
                 ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "rimraf": "^3.0.2",
         "save-svg-as-png": "^1.4.17",
         "shell-path": "^3.0.0",
+        "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
         "win32-api": "^20.1.0"
       },
       "devDependencies": {
@@ -40,7 +41,7 @@
         "builder-util-runtime": "^9.0.3",
         "cross-env": "5.2.1",
         "del": "3.0.0",
-        "electron": "^22.0.2",
+        "electron": "^22.0.3",
         "electron-builder": "23.6.0",
         "electron-builder-squirrel-windows": "20.44.0",
         "electron-icon-maker": "0.0.5",
@@ -77,6 +78,7 @@
         "@symphony/symphony-c9-shell": "3.19.0-0.98.8.132",
         "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
         "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
+        "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
         "winreg": "^1.2.4"
       }
     },
@@ -7505,9 +7507,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "22.0.2",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-22.0.2.tgz",
-      "integrity": "sha1-JWw/d0m8q11o3AukrobBtghS8LM=",
+      "version": "22.0.3",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-22.0.3.tgz",
+      "integrity": "sha1-RIBs0FPqLtNb/+/ZIUPT/GnXM30=",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -19295,6 +19297,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/symphony-native-window-handle-helper": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/finos/SymphonyWindowsHwndHelper.git#5b173043da34a04acf57efd4c1a4317d0a7d1fe4",
+      "hasInstallScript": true,
+      "license": "ISC",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/syntax-error": {
       "version": "1.4.0",
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/syntax-error/-/syntax-error-1.4.0.tgz",
@@ -26769,9 +26781,9 @@
       "peer": true
     },
     "electron": {
-      "version": "22.0.2",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-22.0.2.tgz",
-      "integrity": "sha1-JWw/d0m8q11o3AukrobBtghS8LM=",
+      "version": "22.0.3",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-22.0.3.tgz",
+      "integrity": "sha1-RIBs0FPqLtNb/+/ZIUPT/GnXM30=",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",
@@ -35525,6 +35537,11 @@
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha1-QwY30ki6d+B4iDlR+5qg7tfGP6I=",
       "dev": true
+    },
+    "symphony-native-window-handle-helper": {
+      "version": "git+ssh://git@github.com/finos/SymphonyWindowsHwndHelper.git#5b173043da34a04acf57efd4c1a4317d0a7d1fe4",
+      "from": "symphony-native-window-handle-helper@github:finos/SymphonyWindowsHwndHelper#1.0.1",
+      "optional": true
     },
     "syntax-error": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,10 @@
           "to": "ScreenSnippet.exe"
         },
         {
+          "from": "node_modules/symphony-native-window-handle-helper/SymphonyNativeWindowHandleHelper.exe",
+          "to": "SymphonyNativeWindowHandleHelper.exe"
+        },
+        {
           "from": "node_modules/@symphony/symphony-c9-shell/shell",
           "to": "cloud9/shell",
           "filter": [
@@ -171,7 +175,7 @@
     "builder-util-runtime": "^9.0.3",
     "cross-env": "5.2.1",
     "del": "3.0.0",
-    "electron": "^22.0.2",
+    "electron": "^22.0.3",
     "electron-builder": "23.6.0",
     "electron-builder-squirrel-windows": "20.44.0",
     "electron-icon-maker": "0.0.5",
@@ -226,6 +230,7 @@
     "@symphony/symphony-c9-shell": "3.19.0-0.98.8.132",
     "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
     "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
+    "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
     "winreg": "^1.2.4"
   },
   "ava": {

--- a/scripts/build-win64.bat
+++ b/scripts/build-win64.bat
@@ -55,6 +55,10 @@ if NOT EXIST %SIGNING_FILE_PATH% (
 )
 
 call %SIGNING_FILE_PATH% node_modules\screen-share-indicator-frame\ScreenShareIndicatorFrame.exe
+
+call %SIGNING_FILE_PATH% node_modules\symphony-native-window-handle-helper\SymphonyNativeWindowHandleHelper.exe
+
+
 IF %errorlevel% neq 0 (
 	echo "Signing failed"
 	exit /b -1

--- a/src/app/hwnd-handler.ts
+++ b/src/app/hwnd-handler.ts
@@ -1,4 +1,8 @@
-import { isWindowsOS } from '../common/env';
+import { ExecException, execFile } from 'child_process';
+import { app } from 'electron';
+import * as path from 'path';
+import { isDevEnv, isWindowsOS } from '../common/env';
+import { logger } from '../common/logger';
 
 /**
  * Translate the nativeWindowHandle of an Electron BrowserWindow to the handle
@@ -7,9 +11,71 @@ import { isWindowsOS } from '../common/env';
  * that is positioned below the title bar.
  * @returns translated window handle, or original handle if no applicable translation found
  */
-export const getContentWindowHandle = (nativeWindowHandle: Buffer): Buffer => {
+export const getContentWindowHandle = async (
+  nativeWindowHandle: Buffer,
+): Promise<any> => {
+  const execCmd = (
+    captureUtil: string,
+    captureUtilArgs: ReadonlyArray<string>,
+  ): Promise<any> => {
+    logger.info(
+      `screen-snippet-handlers: execCmd ${captureUtil} ${captureUtilArgs}`,
+    );
+    return new Promise<string>((resolve, reject) => {
+      return execFile(
+        captureUtil,
+        captureUtilArgs,
+        (error: ExecException | null, stdout: any) => {
+          if (error && error.killed) {
+            return reject(error);
+          }
+          resolve(stdout);
+        },
+      );
+    });
+  };
+
+  const convertBuffer = (uint8Arr: Uint8Array) => {
+    let result = 0;
+    for (let i = uint8Arr.length - 1; i >= 0; i--) {
+      result = result * 256 + uint8Arr[i];
+    }
+    return result;
+  };
+
+  const convertToUint8Array = (num: number) => {
+    const arr = new Uint8Array(8);
+    for (let i = 0; i < 8; i++) {
+      arr[i] = num % 256;
+      num = Math.floor(num / 256);
+    }
+    return arr;
+  };
+
   if (!isWindowsOS) {
     return nativeWindowHandle;
   }
-  return nativeWindowHandle;
+  const dec = convertBuffer(nativeWindowHandle);
+  logger.info(`hwnd-handler: getting content hwnd for ${dec}`, dec);
+  const hwndExecPath = isDevEnv
+    ? path.join(
+        __dirname,
+        '../../../node_modules/symphony-native-window-handle-helper/SymphonyNativeWindowHandleHelper.exe',
+      )
+    : path.join(
+        path.dirname(app.getPath('exe')),
+        'SymphonyNativeWindowHandleHelper.exe',
+      );
+  const hwndExecArgs = [dec.toString()];
+  const output = await execCmd(hwndExecPath, hwndExecArgs);
+  if (!output.length) {
+    logger.error(
+      'hwnd-handler: cannot retrieve the right window handle. Returning default one',
+    );
+    return nativeWindowHandle;
+  }
+  const intValue = parseInt(output, 10);
+  logger.info(`hwnd-handler: returning content hwnd for ${dec}: ${intValue}`);
+  const res = convertToUint8Array(intValue);
+  return res;
 };


### PR DESCRIPTION
## Description
Due to Electron 21 upgrade (V8 memory cage enablement), all native APIs dependencies had to be removed.
One direct consequence is on native modules which cannot be used anymore. In our use-case, native modules were helpful to retrieve main BrowserView HWND.
To keep the same feature-level, we implemented a helper to keep retrieving it: https://github.com/finos/SymphonyWindowsHwndHelper
