### PR TITLE
RTC:13399 Forward proxy returned by electron to Cloud9 shell on launch

### DIFF
--- a/spec/c9ShellHandler.spec.ts
+++ b/spec/c9ShellHandler.spec.ts
@@ -1,5 +1,12 @@
 describe('C9 shell handler', () => {
-  const webContentsMocked = { send: jest.fn() };
+  const resolveProxy = jest.fn().mockImplementation(() => Promise.resolve(''));
+  const webContentsMocked = {
+    send: jest.fn(),
+    session: {
+      resolveProxy,
+    },
+    getURL: jest.fn(),
+  };
   const mockSpawnEvents = new Map<String, any>();
   const mockSpawn = jest.fn();
   const mockGetCommandLineArgs = jest.fn();
@@ -48,9 +55,9 @@ describe('C9 shell handler', () => {
   });
 
   describe('launch', () => {
-    it('success', () => {
+    it('success', async () => {
       const { loadC9Shell } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(webContentsMocked.send).lastCalledWith('c9-status-event', {
         status: { status: 'starting' },
       });
@@ -61,9 +68,9 @@ describe('C9 shell handler', () => {
       });
     });
 
-    it('failure', () => {
+    it('failure', async () => {
       const { loadC9Shell } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(webContentsMocked.send).lastCalledWith('c9-status-event', {
         status: { status: 'starting' },
       });
@@ -74,19 +81,19 @@ describe('C9 shell handler', () => {
       });
     });
 
-    it('with attach', () => {
+    it('with attach', async () => {
       mockGetCommandLineArgs.mockReturnValue('--c9pipe=custompipe');
 
       const { loadC9Shell } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(webContentsMocked.send).lastCalledWith('c9-status-event', {
         status: { status: 'active', pipeName: 'symphony-c9-custompipe' },
       });
     });
 
-    it('cached status on relaunch', () => {
+    it('cached status on relaunch', async () => {
       const { loadC9Shell } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(webContentsMocked.send).lastCalledWith('c9-status-event', {
         status: { status: 'starting' },
       });
@@ -102,34 +109,70 @@ describe('C9 shell handler', () => {
       });
     });
 
-    it('args', () => {
+    it('args', async () => {
       mockGetGuid.mockReturnValue('just-another-guid');
 
       const { loadC9Shell } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(mockSpawn).toBeCalledWith(
         expect.stringContaining('c9shell.exe'),
-        ['--symphonyHost', 'just-another-guid'],
+        ['--symphonyHost', 'just-another-guid', '--proxyServer', ''],
         { stdio: 'pipe' },
       );
     });
 
-    it('non-windows', () => {
-      mockIsWindows = false;
-
+    it('args, when resolveProxy returns DIRECT', async () => {
+      webContentsMocked.session.resolveProxy = jest
+        .fn()
+        .mockImplementation(() => Promise.resolve('DIRECT'));
+      mockGetGuid.mockReturnValue('just-another-guid');
       const { loadC9Shell } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+
+      await loadC9Shell(webContentsMocked as any);
+
+      expect(mockSpawn).toBeCalledWith(
+        expect.stringContaining('c9shell.exe'),
+        ['--symphonyHost', 'just-another-guid', '--proxyServer', ''],
+        { stdio: 'pipe' },
+      );
+    });
+
+    it('args, when resolveProxy returns string starting with PROXY ', async () => {
+      webContentsMocked.session.resolveProxy = jest
+        .fn()
+        .mockImplementation(() => Promise.resolve('PROXY 52.207.140.132:8443'));
+      mockGetGuid.mockReturnValue('just-another-guid');
+      const { loadC9Shell } = require('../src/app/c9-shell-handler');
+
+      await loadC9Shell(webContentsMocked as any);
+
+      expect(mockSpawn).toBeCalledWith(
+        expect.stringContaining('c9shell.exe'),
+        [
+          '--symphonyHost',
+          'just-another-guid',
+          '--proxyServer',
+          '52.207.140.132:8443',
+        ],
+        { stdio: 'pipe' },
+      );
+    });
+
+    it('non-windows', async () => {
+      mockIsWindows = false;
+      const { loadC9Shell } = require('../src/app/c9-shell-handler');
+      await loadC9Shell(webContentsMocked as any);
       expect(mockSpawn).not.toBeCalled();
     });
   });
 
   describe('terminate', () => {
-    it('success', () => {
+    it('success', async () => {
       const {
         loadC9Shell,
         terminateC9Shell,
       } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(webContentsMocked.send).lastCalledWith('c9-status-event', {
         status: { status: 'starting' },
       });
@@ -144,12 +187,12 @@ describe('C9 shell handler', () => {
       expect(mockKill).toBeCalledTimes(0);
     });
 
-    it('no terminate if already exited', () => {
+    it('no terminate if already exited', async () => {
       const {
         loadC9Shell,
         terminateC9Shell,
       } = require('../src/app/c9-shell-handler');
-      loadC9Shell(webContentsMocked as any);
+      await loadC9Shell(webContentsMocked as any);
       expect(webContentsMocked.send).lastCalledWith('c9-status-event', {
         status: { status: 'starting' },
       });

--- a/src/app/c9-shell-handler.ts
+++ b/src/app/c9-shell-handler.ts
@@ -24,13 +24,13 @@ class C9ShellHandler {
   /**
    * Starts the c9shell process
    */
-  public startShell() {
+  public async startShell(sender: WebContents) {
     if (this._attachExistingC9Shell()) {
       return;
     }
 
     if (!this._c9shell) {
-      this._c9shell = this._launchC9Shell();
+      this._c9shell = await this._launchC9Shell(sender);
     }
   }
 
@@ -89,9 +89,16 @@ class C9ShellHandler {
   /**
    * Launches the correct c9shell process
    */
-  private _launchC9Shell(): ChildProcess | undefined {
+  private async _launchC9Shell(
+    webContents: WebContents,
+  ): Promise<ChildProcess | undefined> {
     this._curStatus = undefined;
     const uniquePipeName = getGuid();
+    const resolvedProxy =
+      (await webContents.session.resolveProxy(webContents.getURL() ?? '')) ??
+      '';
+    const proxy =
+      resolvedProxy === 'DIRECT' ? '' : resolvedProxy.replace('PROXY ', '');
 
     const c9ShellPath = isDevEnv
       ? path.join(
@@ -109,16 +116,20 @@ class C9ShellHandler {
       ? customC9ShellArgs.substring(9).split(' ')
       : [];
 
-    logger.info('c9-shell: launching shell', c9ShellPath, customC9ShellArgList);
+    customC9ShellArgList.push(
+      ...['--symphonyHost', uniquePipeName, '--proxyServer', proxy],
+    );
+
+    logger.info(
+      'c9-shell: launching shell with path',
+      c9ShellPath,
+      customC9ShellArgList,
+    );
     this._updateStatus({ status: 'starting' });
 
-    const c9Shell = spawn(
-      c9ShellPath,
-      ['--symphonyHost', uniquePipeName, ...customC9ShellArgList],
-      {
-        stdio: 'pipe',
-      },
-    );
+    const c9Shell = spawn(c9ShellPath, customC9ShellArgList, {
+      stdio: 'pipe',
+    });
     c9Shell.on('close', (code) => {
       logger.info('c9-shell: closed with code', code);
       this._c9shell = undefined;
@@ -147,7 +158,7 @@ let c9ShellHandler: C9ShellHandler | undefined;
 /**
  * Starts the C9 shell process asynchronously, if not already started.
  */
-export const loadC9Shell = (sender: WebContents) => {
+export const loadC9Shell = async (sender: WebContents) => {
   if (!isWindowsOS) {
     logger.error("c9-shell: can't load shell on non-Windows OS");
     return;
@@ -159,7 +170,7 @@ export const loadC9Shell = (sender: WebContents) => {
     logger.info('c9-shell: sending status', status);
     sender.send('c9-status-event', { status });
   });
-  c9ShellHandler.startShell();
+  await c9ShellHandler.startShell(sender);
 };
 
 /**

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -423,7 +423,7 @@ ipcMain.on(
         closeC9Pipe();
         break;
       case apiCmds.launchCloud9:
-        loadC9Shell(event.sender);
+        await loadC9Shell(event.sender);
         break;
       case apiCmds.terminateCloud9:
         terminateC9Shell(event.sender);


### PR DESCRIPTION
When a pacfile or proxyServer is passed to SDA, we forward the resolved proxy from webContents.session to Cloud9 shell on launch.