### PR TITLE
RTC-13797 update @symphony/symphony-c9-shell to reduce the size of c9Shell in the SDA installer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.151",
         "@types/lazy-brush": "^1.0.0",
         "archiver": "5.3.1",
         "async.map": "0.5.2",
@@ -74,7 +75,7 @@
         "typescript": "3.9.10"
       },
       "optionalDependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.149",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.151",
         "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
         "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
         "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
@@ -2666,9 +2667,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.149",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.149.tgz",
-      "integrity": "sha512-NnEVhC5raDHPJ7Txhta7AxgQSF4iOE/SHUt4+ZBdQnTOa6aLjR2lkgoHO8hmuj+3HFL/SBDnH36YWr63eu2oqA==",
+      "version": "3.19.0-0.98.15.151",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.151.tgz",
+      "integrity": "sha512-JKNaxt89O4HKDdQsbmwrSzw6EmJc1rawzeIj8YQAcPLNJPTRzI0UKTX09jQRf+lzwIGYOaHFYGMlCEuJu+/8qg==",
       "optional": true
     },
     "node_modules/@szmarczak/http-timer": {
@@ -22844,9 +22845,9 @@
       "dev": true
     },
     "@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.149",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.149.tgz",
-      "integrity": "sha512-NnEVhC5raDHPJ7Txhta7AxgQSF4iOE/SHUt4+ZBdQnTOa6aLjR2lkgoHO8hmuj+3HFL/SBDnH36YWr63eu2oqA==",
+      "version": "3.19.0-0.98.15.151",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.151.tgz",
+      "integrity": "sha512-JKNaxt89O4HKDdQsbmwrSzw6EmJc1rawzeIj8YQAcPLNJPTRzI0UKTX09jQRf+lzwIGYOaHFYGMlCEuJu+/8qg==",
       "optional": true
     },
     "@szmarczak/http-timer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.152",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.153",
         "@types/lazy-brush": "^1.0.0",
         "archiver": "5.3.1",
         "async.map": "0.5.2",
@@ -75,7 +75,7 @@
         "typescript": "3.9.10"
       },
       "optionalDependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.152",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.153",
         "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
         "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
         "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
@@ -2667,9 +2667,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.152",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.152.tgz",
-      "integrity": "sha512-YH4270e57w6pxhLGh/Df1KGSs9mTxOqNkZ0WgUj2hLTuGVcBhd5NniXi+jQufJqd1mH1Fct2yLvzSw12TIJLoQ==",
+      "version": "3.19.0-0.98.15.153",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.153.tgz",
+      "integrity": "sha512-GWTrTtBvJKUU9G49ybz2jvRTy+lpFiZJgyyFFyCERD2a5xl36IHYnv8ZxIDxz6wE4Noszwmw0B+jAP6H7KpjTA==",
       "optional": true
     },
     "node_modules/@szmarczak/http-timer": {
@@ -22845,9 +22845,9 @@
       "dev": true
     },
     "@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.152",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.152.tgz",
-      "integrity": "sha512-YH4270e57w6pxhLGh/Df1KGSs9mTxOqNkZ0WgUj2hLTuGVcBhd5NniXi+jQufJqd1mH1Fct2yLvzSw12TIJLoQ==",
+      "version": "3.19.0-0.98.15.153",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.153.tgz",
+      "integrity": "sha512-GWTrTtBvJKUU9G49ybz2jvRTy+lpFiZJgyyFFyCERD2a5xl36IHYnv8ZxIDxz6wE4Noszwmw0B+jAP6H7KpjTA==",
       "optional": true
     },
     "@szmarczak/http-timer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.153",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.154",
         "@types/lazy-brush": "^1.0.0",
         "archiver": "5.3.1",
         "async.map": "0.5.2",
@@ -75,7 +75,7 @@
         "typescript": "3.9.10"
       },
       "optionalDependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.153",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.154",
         "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
         "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
         "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
@@ -2667,9 +2667,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.153",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.153.tgz",
-      "integrity": "sha512-GWTrTtBvJKUU9G49ybz2jvRTy+lpFiZJgyyFFyCERD2a5xl36IHYnv8ZxIDxz6wE4Noszwmw0B+jAP6H7KpjTA==",
+      "version": "3.19.0-0.98.15.154",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.154.tgz",
+      "integrity": "sha512-BMO+LvrU2z007ICprcA3AWcAMN/X/3Qfk7u88iivp/Y/sn723BP+fQ1oT5OUqfXXxe1tBk8Mf4P4Q2nUyjxcPg==",
       "optional": true
     },
     "node_modules/@szmarczak/http-timer": {
@@ -22845,9 +22845,9 @@
       "dev": true
     },
     "@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.153",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.153.tgz",
-      "integrity": "sha512-GWTrTtBvJKUU9G49ybz2jvRTy+lpFiZJgyyFFyCERD2a5xl36IHYnv8ZxIDxz6wE4Noszwmw0B+jAP6H7KpjTA==",
+      "version": "3.19.0-0.98.15.154",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.154.tgz",
+      "integrity": "sha512-BMO+LvrU2z007ICprcA3AWcAMN/X/3Qfk7u88iivp/Y/sn723BP+fQ1oT5OUqfXXxe1tBk8Mf4P4Q2nUyjxcPg==",
       "optional": true
     },
     "@szmarczak/http-timer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.151",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.152",
         "@types/lazy-brush": "^1.0.0",
         "archiver": "5.3.1",
         "async.map": "0.5.2",
@@ -75,7 +75,7 @@
         "typescript": "3.9.10"
       },
       "optionalDependencies": {
-        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.151",
+        "@symphony/symphony-c9-shell": "3.19.0-0.98.15.152",
         "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
         "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
         "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
@@ -2667,9 +2667,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.151",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.151.tgz",
-      "integrity": "sha512-JKNaxt89O4HKDdQsbmwrSzw6EmJc1rawzeIj8YQAcPLNJPTRzI0UKTX09jQRf+lzwIGYOaHFYGMlCEuJu+/8qg==",
+      "version": "3.19.0-0.98.15.152",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.152.tgz",
+      "integrity": "sha512-YH4270e57w6pxhLGh/Df1KGSs9mTxOqNkZ0WgUj2hLTuGVcBhd5NniXi+jQufJqd1mH1Fct2yLvzSw12TIJLoQ==",
       "optional": true
     },
     "node_modules/@szmarczak/http-timer": {
@@ -22845,9 +22845,9 @@
       "dev": true
     },
     "@symphony/symphony-c9-shell": {
-      "version": "3.19.0-0.98.15.151",
-      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.151.tgz",
-      "integrity": "sha512-JKNaxt89O4HKDdQsbmwrSzw6EmJc1rawzeIj8YQAcPLNJPTRzI0UKTX09jQRf+lzwIGYOaHFYGMlCEuJu+/8qg==",
+      "version": "3.19.0-0.98.15.152",
+      "resolved": "https://repo.symphony.com:443/artifactory/api/npm/npm-virtual-dev/@symphony/symphony-c9-shell/-/@symphony/symphony-c9-shell-3.19.0-0.98.15.152.tgz",
+      "integrity": "sha512-YH4270e57w6pxhLGh/Df1KGSs9mTxOqNkZ0WgUj2hLTuGVcBhd5NniXi+jQufJqd1mH1Fct2yLvzSw12TIJLoQ==",
       "optional": true
     },
     "@szmarczak/http-timer": {

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "win32-api": "^20.1.0"
   },
   "optionalDependencies": {
-    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.149",
+    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.151",
     "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
     "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
     "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "win32-api": "^20.1.0"
   },
   "optionalDependencies": {
-    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.152",
+    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.153",
     "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
     "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
     "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "win32-api": "^20.1.0"
   },
   "optionalDependencies": {
-    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.153",
+    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.154",
     "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
     "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
     "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",

--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
     "win32-api": "^20.1.0"
   },
   "optionalDependencies": {
-    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.151",
+    "@symphony/symphony-c9-shell": "3.19.0-0.98.15.152",
     "screen-share-indicator-frame": "git+https://github.com/finos/ScreenShareIndicatorFrame.git#v1.4.13",
     "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
     "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",


### PR DESCRIPTION
There was a reduction of the installer size by 47 percent. We will be testing the impact. But, the initial testing has been really good.

![image](https://user-images.githubusercontent.com/63641254/220889805-c5834480-12ac-44ed-ae1e-a67ce26a43d7.png)
