### PR TITLE
RTC-13847 TerminateC9Shell when closeAllWrapperWindows command is called.

### DIFF
--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -300,7 +300,11 @@ ipcMain.on(
           await notificationHelper.closeNotification(arg.notificationId);
         }
         break;
+      /**
+       * This gets called from mana, when user logs out
+       */
       case apiCmds.closeAllWrapperWindows:
+        terminateC9Shell();
         windowHandler.closeAllWindows();
         break;
       case apiCmds.setZoomLevel:


### PR DESCRIPTION
Terminate Cloud9 when user logs out of mana. Mana sets closeAllWrapperWindows command to SDA on logout.