### PR TITLE
Screen share indicator missing on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
       "config/Symphony.config",
       "config/titleBarStyles.css",
       "config/InstallVariant.info",
-      "dictionaries/**"
+      "dictionaries/**",
+      "node_modules/screen-share-indicator-frame/SymphonyScreenShareIndicator"
     ],
     "mac": {
       "category": "public.app-category.business",


### PR DESCRIPTION
## Description
Screen share indicator missing on macOS
