### PR TITLE
SDA-4076 Add support for app restart while enabling browser authentication before defining pod URL at first time launch

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -565,7 +565,7 @@ export class WindowHandler {
             url: userConfigUrl,
             message: '',
             urlValid: !!userConfigUrl,
-            isPodConfigured: this.isPodConfigured,
+            isPodConfigured: this.isPodConfigured && !!userConfigUrl,
             isSeamlessLoginEnabled: this.config.enableSeamlessLogin,
           });
           this.didShowWelcomeScreen = true;

--- a/src/renderer/components/welcome.tsx
+++ b/src/renderer/components/welcome.tsx
@@ -151,7 +151,7 @@ export default class Welcome extends React.Component<{}, IState> {
     const url = _event.target.value.trim();
     const match =
       url.match(
-        /(https?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/g,
+        /^https:\/\/.(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/g,
       ) != null;
     if (url === 'https://[POD].symphony.com' || !match) {
       this.updateState(_event, {


### PR DESCRIPTION
## Description
Add support for app restart while enabling browser authentication before defining pod URL at first time launch
Fix for pod URLs: must be prefixed by https
