### PR TITLE
SDA-4091 Disabling electron-builder notarization

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
       "category": "public.app-category.business",
       "icon": "images/icon.icns",
       "entitlements": "entitlements.mac.plist",
+      "notarize": false,
       "entitlementsInherit": "entitlements.mac.plist",
       "gatekeeperAssess": true,
       "hardenedRuntime": true,


### PR DESCRIPTION
## Description
macOS app notarization is handled by CICD pipeline, no need to configure electron-builder to notarize the app.
