### PR TITLE
SDA-4144: The presence status is still shown when reloading SDA

### DIFF
--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -53,6 +53,7 @@ import { notification } from '../renderer/notification';
 import { autoLaunchInstance } from './auto-launch-controller';
 import { autoUpdate, AutoUpdateTrigger } from './auto-update-handler';
 import { mainEvents } from './main-event-handler';
+import { presenceStatus } from './presence-status-handler';
 import { presenceStatusStore } from './stores';
 
 interface IStyles {
@@ -812,6 +813,7 @@ export const reloadWindow = (browserWindow: ICustomBrowserWindow) => {
 
   const windowName = browserWindow.winName;
   const mainWebContents = windowHandler.getMainWebContents();
+  const main = windowHandler.getMainWindow();
   // reload the main window
   if (
     windowName === apiName.mainWindowName &&
@@ -822,6 +824,8 @@ export const reloadWindow = (browserWindow: ICustomBrowserWindow) => {
     mainWebContents.reload();
 
     windowHandler.closeAllWindows();
+    main?.setThumbarButtons([]);
+    presenceStatus.onSignOut();
 
     windowHandler.closeScreenSharingIndicator();
 


### PR DESCRIPTION
## Description
Reload will no longer:
- Show badges (Presence and Notif)
- Show Systray Presence Menu
- Show Systray Presence

While logging out Reload will no longer
- Show badges (Presence and Notif)
- Show Systray Presence Menu
- Show Systray Presence

While going to admin page Reload will no longer
- Show badges (Presence and Notif)
- Show Systray Presence Menu
- Show Systray Presence

While going to be signed out (Suspended, Deactivated) Reload will no longer
- Show badges (Presence and Notif)
- Show Systray Presence Menu
- Show Systray Presence

## Related PRs
