### PR TITLE
SDA-4143: Add complete flow for authentication control

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -175,9 +175,7 @@ export class WindowHandler {
   private readonly opts: Electron.BrowserViewConstructorOptions | undefined;
   private hideOnCapture: boolean = false;
   private currentWindow?: string = undefined;
-  private isPodConfigured: boolean = false;
   private shouldShowWelcomeScreen: boolean = true;
-  private didShowWelcomeScreen: boolean = false;
   private defaultUrl: string = 'my.symphony.com';
 
   constructor(opts?: Electron.BrowserViewConstructorOptions) {
@@ -251,11 +249,10 @@ export class WindowHandler {
       this.config.isCustomTitleBar === CloudConfigDataTypes.ENABLED;
     // Get url to load from cmd line or from global config file
     const urlFromCmd = getCommandLineArgs(process.argv, '--url=', false);
-    this.isPodConfigured = !config.isFirstTimeLaunch();
-    this.didShowWelcomeScreen = false;
     this.shouldShowWelcomeScreen =
-      this.globalConfig.url.includes(this.defaultUrl) &&
-      (config.isFirstTimeLaunch() || !!this.config.enableBrowserLogin);
+      (this.globalConfig.url.includes(this.defaultUrl) &&
+        config.isFirstTimeLaunch()) ||
+      !!this.config.enableBrowserLogin;
 
     this.windowOpts = {
       ...this.getWindowOpts(
@@ -551,7 +548,7 @@ export class WindowHandler {
 
       if (this.mainWebContents && !this.mainWebContents.isDestroyed()) {
         // Load welcome screen
-        if (this.shouldShowWelcomeScreen && !this.didShowWelcomeScreen) {
+        if (this.shouldShowWelcomeScreen) {
           const podUrl = this.userConfig.url
             ? this.userConfig.url
             : !this.globalConfig.url.includes(this.defaultUrl)
@@ -565,11 +562,10 @@ export class WindowHandler {
             url: podUrl,
             message: '',
             urlValid: !!podUrl,
-            isPodConfigured: this.isPodConfigured && !!podUrl,
+            isPodConfigured: !!podUrl,
             isBrowserLoginEnabled: this.config.enableBrowserLogin,
             browserLoginAutoConnect: this.config.browserLoginAutoConnect,
           });
-          this.didShowWelcomeScreen = true;
           this.mainWebContents.focus();
         }
 


### PR DESCRIPTION
## Description
Add complete flow for authentication control
With these 6 cases:

Case 1
SSO: false
BrowserLogin: false
POD_URL: false
--> Show Enter Pod

Case 2
SSO: true
BrowserLogin: false
POD_URL: true
--> Show SSO Page

Case 3
SSO: false
BrowserLogin: true
POD_URL: false
--> Show Browser Login page

Case 4
SSO: true
BrowserLogin: true
POD_URL: true
--> Show Browser Login without POD URL Page

Case 5
SSO: false
BrowserLogin: true
POD_URL: true
--> Show Browser Login without POD URL Page


Case 6
SSO: false
BrowserLogin: false
POD_URL: true
--> Show Browser Login without POD URL Page
## Related PRs
