### PR TITLE
SDA-4204 Show only visible windows to prevent showing back hidden toast notifications while taking a screenshot

### DIFF
--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -474,6 +474,7 @@ class ScreenSnippet {
           focused: mainWindow?.isFocused(),
           minimized: mainWindow?.isMinimized(),
           isFullScreen: mainWindow?.isFullScreen(),
+          isVisible: mainWindow?.isVisible(),
         },
       ];
 
@@ -487,6 +488,7 @@ class ScreenSnippet {
             focused: window.isFocused(),
             minimized: window?.isMinimized(),
             isFullScreen: window?.isFullScreen(),
+            isVisible: window?.isVisible(),
           });
         }
       });
@@ -497,6 +499,7 @@ class ScreenSnippet {
           focused: currentWindowObj?.isFocused(),
           minimized: currentWindowObj?.isMinimized(),
           isFullScreen: currentWindowObj?.isFullScreen(),
+          isVisible: currentWindowObj?.isVisible(),
         });
         windowsArr = mainArr.concat(windowsArr);
       } else {

--- a/src/app/stores/window-store.ts
+++ b/src/app/stores/window-store.ts
@@ -15,6 +15,7 @@ export interface IWindowState {
   minimized?: boolean;
   focused?: boolean;
   isFullScreen?: boolean;
+  isVisible?: boolean;
 }
 
 export class WindowStore {
@@ -77,7 +78,7 @@ export class WindowStore {
       const fullscreenedWindows: IWindowState[] = [];
       // Restoring all windows except focused one
       storedWindows.windows.forEach((currentWindow) => {
-        if (currentWindow) {
+        if (currentWindow && currentWindow.isVisible) {
           const window: ICustomBrowserWindow | undefined = getWindowByName(
             currentWindow.id || '',
           ) as ICustomBrowserWindow;


### PR DESCRIPTION
## Description
Closing a toast notification hides it. Thus, taking a screenshot after closing a toast notification will make it appear while restoring the app. This PR aims at fixing this bug.
