### PR TITLE
Always on top windows should be restored as is after taking a screenshot and prevent hiding toast notifications

### DIFF
--- a/src/app/screen-snippet-handler.ts
+++ b/src/app/screen-snippet-handler.ts
@@ -475,6 +475,7 @@ class ScreenSnippet {
           minimized: mainWindow?.isMinimized(),
           isFullScreen: mainWindow?.isFullScreen(),
           isVisible: mainWindow?.isVisible(),
+          isAlwaysOnTop: mainWindow?.isAlwaysOnTop(),
         },
       ];
 
@@ -489,6 +490,7 @@ class ScreenSnippet {
             minimized: window?.isMinimized(),
             isFullScreen: window?.isFullScreen(),
             isVisible: window?.isVisible(),
+            isAlwaysOnTop: window?.isAlwaysOnTop(),
           });
         }
       });
@@ -500,6 +502,7 @@ class ScreenSnippet {
           minimized: currentWindowObj?.isMinimized(),
           isFullScreen: currentWindowObj?.isFullScreen(),
           isVisible: currentWindowObj?.isVisible(),
+          isAlwaysOnTop: currentWindowObj?.isAlwaysOnTop(),
         });
         windowsArr = mainArr.concat(windowsArr);
       } else {

--- a/src/app/stores/window-store.ts
+++ b/src/app/stores/window-store.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron';
 import { presenceStatusStore } from '.';
+import { apiName } from '../../common/api-interface';
 import { isMac, isWindowsOS } from '../../common/env';
 import { logger } from '../../common/logger';
 import { presenceStatus } from '../presence-status-handler';
@@ -16,6 +17,7 @@ export interface IWindowState {
   focused?: boolean;
   isFullScreen?: boolean;
   isVisible?: boolean;
+  isAlwaysOnTop?: boolean;
 }
 
 export class WindowStore {
@@ -49,11 +51,16 @@ export class WindowStore {
       currentWindows.forEach((currentWindow) => {
         const isFullScreen = currentWindow.isFullScreen();
         const isMinimized = currentWindow.isMinimized();
-        if (isFullScreen) {
-          this.hideFullscreenWindow(currentWindow);
-          // No need to hide minimized windows
-        } else if (!isMinimized) {
-          currentWindow?.hide();
+        if (
+          (currentWindow as ICustomBrowserWindow).winName !==
+          apiName.notificationWindowName
+        ) {
+          if (isFullScreen) {
+            this.hideFullscreenWindow(currentWindow);
+            // No need to hide minimized windows
+          } else if (!isMinimized) {
+            currentWindow?.hide();
+          }
         }
       });
     }
@@ -95,6 +102,9 @@ export class WindowStore {
             if (currentWindow.focused) {
               focusedWindowToRestore = window;
             }
+          }
+          if (currentWindow && currentWindow.isAlwaysOnTop) {
+            window.setAlwaysOnTop(true);
           }
         }
       });


### PR DESCRIPTION
## Description
Always on top windows should be restored as is after taking a screenshot and prevent hiding toast notifications
