### PR TITLE
SDA-4196 Safe uptime retrieval

### DIFF
--- a/src/app/stats.ts
+++ b/src/app/stats.ts
@@ -41,7 +41,7 @@ export class AppStats {
     } catch (error) {
       logger.error('stats: Error getting machine uptime', error);
     }
-    logger.info(`Uptime -> `, os.uptime());
+    logger.info(`Uptime -> `, uptime);
     logger.info(`User Info (OS Returned) -> `, os.userInfo());
   }
 


### PR DESCRIPTION
## Description
Error handling introduced while retrieving uptime value on NodeJS >= v16.18 
Details available here:
https://github.com/nodejs/node/pull/44886
https://github.com/nodejs/node/pull/44386

This can raise an error if it fails retrieving the value.

Goal is to wrap value retrieval and avoid js error being raised.

