### PR TITLE
SDA-4223: Add new option to overwrite auto-update pmp

### DIFF
--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -45,6 +45,11 @@ sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#
 sed -i "" -E "s#\"enableBrowserLogin\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"enableBrowserLogin\":\ $enable_browser_login#g" "${newPath}"
 sed -i "" -E "s#\"browserLoginAutoConnect\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"browserLoginAutoConnect\":\ $browser_login_autoconnect#g" "${newPath}"
 
+## Add settings force auto update
+force_auto_update=$(sed -n '10p' ${settingsFilePath});
+if [ "$force_auto_update" = "" ]; then force_auto_update=false; fi
+sed -i "" -E "s#\"forceAutoUpdate\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"forceAutoUpdate\":\ $force_auto_update#g" "${newPath}"
+
 ## Get Symphony Permissions from the temp file ##
 media=$(sed -n '1p' ${permissionsFilePath});
 geo_location=$(sed -n '2p' ${permissionsFilePath});

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -160,6 +160,7 @@ class Script
             new PublicProperty("OVERRIDE_USER_AGENT", "false"),
             new PublicProperty("ENABLE_BROWSER_LOGIN", "false"),
             new PublicProperty("BROWSER_LOGIN_AUTOCONNECT", "false"),
+            new PublicProperty("FORCE_AUTO_UPDATE","false"),
             new PublicProperty("CHROME_FLAGS", ""),
             new Property("MSIINSTALLPERUSER", "1"),
             new Property("PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%"))
@@ -188,7 +189,7 @@ class Script
             new ElevatedManagedAction(CustomActions.UpdateConfig, Return.check, When.After, Step.InstallFiles, Condition.NOT_BeingRemoved )
             {
                 // The UpdateConfig action needs the built-in property INSTALLDIR as well as most of the custom properties
-                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH,USER_DATA_PATH,OVERRIDE_USER_AGENT,CHROME_FLAGS,ENABLE_BROWSER_LOGIN,BROWSER_LOGIN_AUTOCONNECT"
+                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH,USER_DATA_PATH,OVERRIDE_USER_AGENT,CHROME_FLAGS,ENABLE_BROWSER_LOGIN,BROWSER_LOGIN_AUTOCONNECT,FORCE_AUTO_UPDATE"
             },
 
             // CleanRegistry
@@ -364,6 +365,7 @@ public class CustomActions
             data = ReplaceBooleanProperty(data, "overrideUserAgent", session.Property("OVERRIDE_USER_AGENT"));
             data = ReplaceBooleanProperty(data, "enableBrowserLogin", session.Property("ENABLE_BROWSER_LOGIN"));
             data = ReplaceBooleanProperty(data, "browserLoginAutoConnect", session.Property("BROWSER_LOGIN_AUTOCONNECT"));
+            data = ReplaceBooleanProperty(data, "forceAutoUpdate", session.Property("FORCE_AUTO_UPDATE"));
             // Write the contents back to the file
             System.IO.File.WriteAllText(filename, data);
         }

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -565,6 +565,20 @@ Expected values:
 * "false"
   User will need to click on Login button to start browser login flow.
 
+-------------------------------------------------------------------
+### FORCE_AUTO_UPDATE
+
+The provided property will enable user ability to overwrite PMP settings of auto update. Thus,
+the update option will take "FORCE_AUTO_UPDATE" first then consider PMP later
+By default its value will be 'false'
+
+Expected values:
+
+* "true"
+  Allow user to check for update regardless conditions
+* "false"
+  Will also consider PMP settings
+
 #### Example, install with browser login autoconnect enabled
 
     msiexec /i Symphony.msi BROWSER_LOGIN_AUTOCONNECT="true"
@@ -576,3 +590,10 @@ Expected values:
 or
 
     msiexec /i Symphony.msi
+
+#### Example, install with force auto-update
+
+    msiexec /i Symphony.msi FORCE_AUTO_UPDATE="true"
+or
+    msiexec /i Symphony.msi
+    This equals to msiexec /i Symphony.msi FORCE_AUTO_UPDATE="false"

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -85,6 +85,7 @@ const menuItemConfigFields = [
   'devToolsEnabled',
   'isAutoUpdateEnabled',
   'enableBrowserLogin',
+  'forceAutoUpdate',
 ];
 
 let {
@@ -97,6 +98,7 @@ let {
   devToolsEnabled,
   isAutoUpdateEnabled,
   enableBrowserLogin,
+  forceAutoUpdate,
 } = config.getConfigFields(menuItemConfigFields) as IConfig;
 let initialAnalyticsSent = false;
 const CORP_URL = 'https://corporate.symphony.com';
@@ -243,6 +245,7 @@ export class AppMenu {
     devToolsEnabled = configData.devToolsEnabled;
     isAutoUpdateEnabled = configData.isAutoUpdateEnabled;
     enableBrowserLogin = configData.enableBrowserLogin;
+    forceAutoUpdate = configData.forceAutoUpdate;
     // fetch updated cloud config
     this.cloudConfig = config.getFilteredCloudConfigFields(
       this.menuItemConfigFields,
@@ -307,7 +310,10 @@ export class AppMenu {
           click: (_item) => {
             autoUpdate.checkUpdates(AutoUpdateTrigger.MANUAL);
           },
-          visible: isMac && !!isAutoUpdateEnabled && !!windowHandler.isMana,
+          visible:
+            isMac &&
+            !!(isAutoUpdateEnabled || forceAutoUpdate) &&
+            !!windowHandler.isMana,
           label: i18n.t('Check for updates')(),
         },
         this.buildSeparator(),
@@ -706,7 +712,9 @@ export class AppMenu {
             autoUpdate.checkUpdates(AutoUpdateTrigger.MANUAL);
           },
           visible:
-            isWindowsOS && !!isAutoUpdateEnabled && !!windowHandler.isMana,
+            isWindowsOS &&
+            !!(isAutoUpdateEnabled || forceAutoUpdate) &&
+            !!windowHandler.isMana,
           label: i18n.t('Check for updates')(),
         },
         {

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -61,6 +61,7 @@ export interface IConfig {
   enableBrowserLogin?: boolean;
   browserLoginAutoConnect?: boolean;
   betaAutoUpdateChannelEnabled?: boolean;
+  forceAutoUpdate?: boolean;
 }
 
 export interface IGlobalConfig {

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -1089,6 +1089,7 @@ export const updateFeaturesForCloudConfig = async (
     memoryThreshold,
     isAutoUpdateEnabled,
     autoUpdateCheckInterval,
+    forceAutoUpdate,
   } = config.getConfigFields([
     'launchOnStartup',
     'alwaysOnTop',
@@ -1096,6 +1097,7 @@ export const updateFeaturesForCloudConfig = async (
     'memoryThreshold',
     'isAutoUpdateEnabled',
     'autoUpdateCheckInterval',
+    'forceAutoUpdate',
   ]) as IConfig;
 
   const mainWebContents = windowHandler.getMainWebContents();
@@ -1147,7 +1149,7 @@ export const updateFeaturesForCloudConfig = async (
 
   // SDA auto updater
   logger.info(`window-utils: initiate auto update?`, isAutoUpdateEnabled);
-  if (isAutoUpdateEnabled) {
+  if (forceAutoUpdate || isAutoUpdateEnabled) {
     if (!autoUpdateIntervalId) {
       // randomised to avoid having all users getting SDA update at the same time
       autoUpdateIntervalId = setInterval(async () => {


### PR DESCRIPTION
## Description
Add a new setting into config
"forceAutoUpdate"
Add new argument for msiexec
CMD: "FORCE_AUTO_UPDATE"

This config will have a higher authority since it can overwrite the config at higher level. Make local a preferable config, for Auto-update
## Related PRs
