### PR TITLE
SDA-4227 (Update electron-updater version to 6.1.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "electron-dl": "3.5.0",
         "electron-fetch": "1.9.1",
         "electron-log": "4.4.8",
-        "electron-updater": "^5.0.1",
+        "electron-updater": "^6.1.3",
         "filesize": "^10.0.6",
         "lazy-brush": "^1.0.1",
         "react": "16.14.0",
@@ -3062,10 +3062,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/semver": {
-      "version": "7.3.9",
-      "license": "MIT"
-    },
     "node_modules/@types/stack-utils": {
       "version": "1.0.1",
       "dev": true,
@@ -4802,7 +4798,6 @@
     },
     "node_modules/builder-util-runtime": {
       "version": "9.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -6976,28 +6971,18 @@
       "license": "ISC"
     },
     "node_modules/electron-updater": {
-      "version": "5.0.1",
-      "license": "MIT",
+      "version": "6.1.3",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron-updater/-/electron-updater-6.1.3.tgz",
+      "integrity": "sha512-qOaSBVbAPSD5YNg5ZNVFYHGdxuNTaRLa+BPOEowfN2n/KEAbWv6Wi39zLapupK+1P+SZUdZvZcZAuXkBoCzY4w==",
       "dependencies": {
-        "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.0",
-        "fs-extra": "^10.0.0",
+        "builder-util-runtime": "9.2.1",
+        "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.3.5"
-      }
-    },
-    "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.2",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "semver": "^7.3.8",
+        "tiny-typed-emitter": "^2.1.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {
@@ -7023,8 +7008,9 @@
       }
     },
     "node_modules/electron-updater/node_modules/semver": {
-      "version": "7.3.7",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -17164,6 +17150,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
     "node_modules/tinycolor2": {
       "version": "1.4.2",
       "dev": true,
@@ -20589,9 +20580,6 @@
       "version": "0.16.2",
       "dev": true
     },
-    "@types/semver": {
-      "version": "7.3.9"
-    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "dev": true
@@ -21859,7 +21847,6 @@
     },
     "builder-util-runtime": {
       "version": "9.2.1",
-      "dev": true,
       "requires": {
         "debug": "^4.3.4",
         "sax": "^1.2.4"
@@ -23319,25 +23306,20 @@
       "dev": true
     },
     "electron-updater": {
-      "version": "5.0.1",
+      "version": "6.1.3",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron-updater/-/electron-updater-6.1.3.tgz",
+      "integrity": "sha512-qOaSBVbAPSD5YNg5ZNVFYHGdxuNTaRLa+BPOEowfN2n/KEAbWv6Wi39zLapupK+1P+SZUdZvZcZAuXkBoCzY4w==",
       "requires": {
-        "@types/semver": "^7.3.6",
-        "builder-util-runtime": "9.0.0",
-        "fs-extra": "^10.0.0",
+        "builder-util-runtime": "9.2.1",
+        "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.3.5"
+        "semver": "^7.3.8",
+        "tiny-typed-emitter": "^2.1.0"
       },
       "dependencies": {
-        "builder-util-runtime": {
-          "version": "9.0.0",
-          "requires": {
-            "debug": "^4.3.2",
-            "sax": "^1.2.4"
-          }
-        },
         "fs-extra": {
           "version": "10.1.0",
           "requires": {
@@ -23354,7 +23336,9 @@
           }
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.5.4",
+          "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -30324,6 +30308,11 @@
     "timm": {
       "version": "1.7.1",
       "dev": true
+    },
+    "tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
     "tinycolor2": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "electron-dl": "3.5.0",
     "electron-fetch": "1.9.1",
     "electron-log": "4.4.8",
-    "electron-updater": "^5.0.1",
+    "electron-updater": "^6.1.3",
     "filesize": "^10.0.6",
     "lazy-brush": "^1.0.1",
     "react": "16.14.0",


### PR DESCRIPTION
## Description
Update `electron-updater` version to `6.1.3` from `5.0.1`

There are no breaking changes from version `5.0.1` to `6.1.3`, apart from major changes in the cache directory on macOS which is not causing any issue