### PR TITLE
SDA-4219 (Change logic to use minimize/restore instead of hide/show)

### DIFF
--- a/src/app/stores/window-store.ts
+++ b/src/app/stores/window-store.ts
@@ -1,7 +1,6 @@
 import { BrowserWindow } from 'electron';
 import { presenceStatusStore } from '.';
 import { apiName } from '../../common/api-interface';
-import { isMac, isWindowsOS } from '../../common/env';
 import { logger } from '../../common/logger';
 import { presenceStatus } from '../presence-status-handler';
 import { ICustomBrowserWindow, windowHandler } from '../window-handler';
@@ -48,18 +47,11 @@ export class WindowStore {
       const currentWindows = BrowserWindow.getAllWindows();
 
       currentWindows.forEach((currentWindow) => {
-        const isFullScreen = currentWindow.isFullScreen();
-        const isMinimized = currentWindow.isMinimized();
         if (
           (currentWindow as ICustomBrowserWindow).winName !==
           apiName.notificationWindowName
         ) {
-          if (isFullScreen) {
-            this.hideFullscreenWindow(currentWindow);
-            // No need to hide minimized windows
-          } else if (!isMinimized) {
-            currentWindow?.hide();
-          }
+          currentWindow.minimize();
         }
       });
     }
@@ -90,15 +82,7 @@ export class WindowStore {
             currentWindow.id || '',
           ) as ICustomBrowserWindow;
           if (window) {
-            if (currentWindow.isFullScreen) {
-              fullscreenedWindows.push(currentWindow);
-              // Window should be shown before putting it in fullscreen on Windows
-              if (isWindowsOS) {
-                window.show();
-              }
-            } else if (!currentWindow.minimized && !currentWindow.focused) {
-              window.showInactive();
-            }
+            window.restore();
             if (currentWindow.focused) {
               focusedWindowToRestore = window;
             }
@@ -148,7 +132,7 @@ export class WindowStore {
       });
   };
 
-  private hideFullscreenWindow = (window: BrowserWindow) => {
+  /*private hideFullscreenWindow = (window: BrowserWindow) => {
     window.once('leave-full-screen', () => {
       if (isMac) {
         window.hide();
@@ -159,7 +143,7 @@ export class WindowStore {
       }
     });
     window.setFullScreen(false);
-  };
+  };*/
 
   /**
    * Restores windows that are in fullscreen and focus on the right window

--- a/src/app/stores/window-store.ts
+++ b/src/app/stores/window-store.ts
@@ -132,19 +132,6 @@ export class WindowStore {
       });
   };
 
-  /*private hideFullscreenWindow = (window: BrowserWindow) => {
-    window.once('leave-full-screen', () => {
-      if (isMac) {
-        window.hide();
-      } else {
-        setTimeout(() => {
-          window.hide();
-        }, 0);
-      }
-    });
-    window.setFullScreen(false);
-  };*/
-
   /**
    * Restores windows that are in fullscreen and focus on the right window
    * On macOS, windows in fullscreen need to be restore one by one


### PR DESCRIPTION
## Description
- Change logic to use minimize/restore for `Windows` and hide/show for `macOS`

## Demo
Popout
![popout](https://github.com/finos/SymphonyElectron/assets/13243259/d03a5d8e-8aed-4489-9589-2dc5facb673b)

Fullscreen
![full_screen](https://github.com/finos/SymphonyElectron/assets/13243259/cc25a058-645f-4c15-92cc-2340bde5d668)

Minimize / Restore single window
![Animation](https://github.com/finos/SymphonyElectron/assets/13243259/4c644ff5-ed47-483d-b88c-3c8ae850e74b)

