### PR TITLE
SDA-4288_main: Add config to allow / disallow user to edit podconfig

### DIFF
--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -3,6 +3,7 @@
     "autoUpdateUrl": "",
     "autoUpdateChannel": "latest",
     "isAutoUpdateEnabled": true,
+    "isPodUrlEditable": true,
     "forceAutoUpdate": false,
     "autoUpdateCheckInterval": "30",
     "enableBrowserLogin": false,

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -50,6 +50,11 @@ force_auto_update=$(sed -n '10p' ${settingsFilePath});
 if [ "$force_auto_update" = "" ]; then force_auto_update=false; fi
 sed -i "" -E "s#\"forceAutoUpdate\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"forceAutoUpdate\":\ $force_auto_update#g" "${newPath}"
 
+## Add settings is pod url editable
+is_pod_url_editable=$(sed -n '11p' ${settingsFilePath});
+if [ "$is_pod_url_editable" = "" ]; then is_pod_url_editable=true; fi
+sed -i "" -E "s#\"isPodUrlEditable\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"isPodUrlEditable\":\ $is_pod_url_editable#g" "${newPath}"
+
 ## Get Symphony Permissions from the temp file ##
 media=$(sed -n '1p' ${permissionsFilePath});
 geo_location=$(sed -n '2p' ${permissionsFilePath});

--- a/installer/win/WixSharpInstaller/Symphony.cs
+++ b/installer/win/WixSharpInstaller/Symphony.cs
@@ -161,6 +161,7 @@ class Script
             new PublicProperty("ENABLE_BROWSER_LOGIN", "false"),
             new PublicProperty("BROWSER_LOGIN_AUTOCONNECT", "false"),
             new PublicProperty("FORCE_AUTO_UPDATE","false"),
+            new PublicProperty("IS_POD_URL_EDITABLE","true"),
             new PublicProperty("CHROME_FLAGS", ""),
             new Property("MSIINSTALLPERUSER", "1"),
             new Property("PROGRAMSFOLDER", System.Environment.ExpandEnvironmentVariables(@"%PROGRAMFILES%"))
@@ -189,7 +190,7 @@ class Script
             new ElevatedManagedAction(CustomActions.UpdateConfig, Return.check, When.After, Step.InstallFiles, Condition.NOT_BeingRemoved )
             {
                 // The UpdateConfig action needs the built-in property INSTALLDIR as well as most of the custom properties
-                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH,USER_DATA_PATH,OVERRIDE_USER_AGENT,CHROME_FLAGS,ENABLE_BROWSER_LOGIN,BROWSER_LOGIN_AUTOCONNECT,FORCE_AUTO_UPDATE"
+                UsesProperties = "INSTALLDIR,POD_URL,CONTEXT_ORIGIN_URL,MINIMIZE_ON_CLOSE,ALWAYS_ON_TOP,AUTO_START,BRING_TO_FRONT,MEDIA,LOCATION,NOTIFICATIONS,MIDI_SYSEX,POINTER_LOCK,FULL_SCREEN,OPEN_EXTERNAL,CUSTOM_TITLE_BAR,DEV_TOOLS_ENABLED,AUTO_LAUNCH_PATH,USER_DATA_PATH,OVERRIDE_USER_AGENT,CHROME_FLAGS,ENABLE_BROWSER_LOGIN,BROWSER_LOGIN_AUTOCONNECT,FORCE_AUTO_UPDATE,IS_POD_URL_EDITABLE"
             },
 
             // CleanRegistry
@@ -366,6 +367,7 @@ public class CustomActions
             data = ReplaceBooleanProperty(data, "enableBrowserLogin", session.Property("ENABLE_BROWSER_LOGIN"));
             data = ReplaceBooleanProperty(data, "browserLoginAutoConnect", session.Property("BROWSER_LOGIN_AUTOCONNECT"));
             data = ReplaceBooleanProperty(data, "forceAutoUpdate", session.Property("FORCE_AUTO_UPDATE"));
+            data = ReplaceBooleanProperty(data, "isPodUrlEditable", session.Property("IS_POD_URL_EDITABLE"));
             // Write the contents back to the file
             System.IO.File.WriteAllText(filename, data);
         }

--- a/installer/win/install_instructions_win.md
+++ b/installer/win/install_instructions_win.md
@@ -579,6 +579,19 @@ Expected values:
 * "false"
   Will also consider PMP settings
 
+-------------------------------------------------------------------
+### IS_POD_URL_EDITABLE
+
+Allow user to edit the POD via triple click on url at 'About Us'
+By default its value will be 'true'
+
+Expected values:
+
+* "true"
+  Allow user to edit pod url
+* "false"
+  Prevent user from editing pod url
+
 #### Example, install with browser login autoconnect enabled
 
     msiexec /i Symphony.msi BROWSER_LOGIN_AUTOCONNECT="true"
@@ -597,3 +610,10 @@ or
 or
     msiexec /i Symphony.msi
     This equals to msiexec /i Symphony.msi FORCE_AUTO_UPDATE="false"
+
+#### Example, install with pod url not editable
+
+    msiexec /i Symphony.msi IS_POD_URL_EDITABLE="false"
+or
+    msiexec /i Symphony.msi
+    This equals to msiexec /i Symphony.msi IS_POD_URL_EDITABLE="true"

--- a/spec/aboutApp.spec.ts
+++ b/spec/aboutApp.spec.ts
@@ -9,7 +9,7 @@ describe('about app', () => {
   const aboutDataMock = {
     sbeVersion: '1',
     userConfig: {},
-    globalConfig: {},
+    globalConfig: { isPodUrlEditable: true },
     cloudConfig: {},
     finalConfig: {},
     appName: 'Symphony',
@@ -81,6 +81,54 @@ describe('about app', () => {
   it('should display input when triple clicked on pod', () => {
     const wrapper = shallow(React.createElement(AboutApp));
     ipcRenderer.send('about-app-data', aboutDataMock);
+    const pod = wrapper.find(`[data-testid="POD_INFO"]`);
+    pod.simulate('click', { detail: 1 });
+    pod.simulate('click', { detail: 2 });
+    pod.simulate('click', { detail: 3 });
+    const podInput = wrapper.find('.AboutApp-pod-input');
+    expect(podInput.exists()).toEqual(true);
+  });
+
+  it('should not display input when triple clicked on pod', () => {
+    const cloneAboutDataMock = aboutDataMock;
+
+    cloneAboutDataMock.globalConfig = { isPodUrlEditable: false };
+    cloneAboutDataMock.userConfig = { isPodUrlEditable: true };
+
+    const wrapper = shallow(React.createElement(AboutApp));
+    ipcRenderer.send('about-app-data', cloneAboutDataMock);
+    const pod = wrapper.find(`[data-testid="POD_INFO"]`);
+    pod.simulate('click', { detail: 1 });
+    pod.simulate('click', { detail: 2 });
+    pod.simulate('click', { detail: 3 });
+    const podInput = wrapper.find('.AboutApp-pod-input');
+    expect(podInput.exists()).toEqual(false);
+  });
+
+  it('should not display config based on global config only', () => {
+    const cloneAboutDataMock = aboutDataMock;
+
+    cloneAboutDataMock.globalConfig = { isPodUrlEditable: false };
+    cloneAboutDataMock.userConfig = { isPodUrlEditable: false };
+
+    const wrapper = shallow(React.createElement(AboutApp));
+    ipcRenderer.send('about-app-data', cloneAboutDataMock);
+    const pod = wrapper.find(`[data-testid="POD_INFO"]`);
+    pod.simulate('click', { detail: 1 });
+    pod.simulate('click', { detail: 2 });
+    pod.simulate('click', { detail: 3 });
+    const podInput = wrapper.find('.AboutApp-pod-input');
+    expect(podInput.exists()).toEqual(false);
+  });
+
+  it('should display config based on global config only', () => {
+    const cloneAboutDataMock = aboutDataMock;
+
+    cloneAboutDataMock.globalConfig = { isPodUrlEditable: true };
+    cloneAboutDataMock.userConfig = { isPodUrlEditable: false };
+
+    const wrapper = shallow(React.createElement(AboutApp));
+    ipcRenderer.send('about-app-data', cloneAboutDataMock);
     const pod = wrapper.find(`[data-testid="POD_INFO"]`);
     pod.simulate('click', { detail: 1 });
     pod.simulate('click', { detail: 2 });

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -62,6 +62,7 @@ export interface IConfig {
   browserLoginAutoConnect?: boolean;
   betaAutoUpdateChannelEnabled?: boolean;
   forceAutoUpdate?: boolean;
+  isPodUrlEditable?: boolean;
 }
 
 export interface IGlobalConfig {

--- a/src/renderer/components/about-app.tsx
+++ b/src/renderer/components/about-app.tsx
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import { ipcRenderer } from 'electron';
 import * as React from 'react';
 import { productName } from '../../../package.json';
+import { IConfig } from '../../app/config-handler';
 import { apiCmds, apiName } from '../../common/api-interface';
 import { i18n } from '../../common/i18n-preload';
 import * as CopyIcon from '../../renderer/assets/copy-icon.svg';
@@ -250,8 +251,9 @@ export default class AboutApp extends React.Component<{}, IState> {
   public onPodClick(e): void {
     if (e.detail === 3) {
       this.setState({
-        isPodEditing: true,
-        didUpdateHostname: true,
+        isPodEditing: !!(this.state.globalConfig as IConfig)?.isPodUrlEditable,
+        didUpdateHostname: !!(this.state.globalConfig as IConfig)
+          ?.isPodUrlEditable,
       });
     }
   }


### PR DESCRIPTION
## Description
Add config to allow / disallow user to edit podconfig

User can add this property via:
in Command line: msiexec /i Symphony.msi IS_POD_URL_EDITABLE="false"
in Config file: isPodUrlEditable

## Related PRs
