### PR TITLE
SDA-4352 Devtools shortcut fix - DraftJS is considering Ctrl + I as italic

### DIFF
--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -457,9 +457,16 @@ export class WindowHandler {
       windowHandler.switchClient(clientSwitchType);
     }, SHORTCUT_KEY_THROTTLE);
     this.mainWebContents.on('before-input-event', (event, input) => {
+      const windowsDevTools =
+        input.control && input.shift && input.key.toLowerCase() === 'i';
+      const macDevTools =
+        input.meta && input.alt && input.key.toLowerCase() === 'i';
       if (input.control && input.shift && input.key.toLowerCase() === 'd') {
         event.preventDefault();
         throttledExportLogs();
+      } else if (windowsDevTools || macDevTools) {
+        event.preventDefault();
+        this.mainWebContents?.toggleDevTools();
       }
       const isCtrlOrMeta = isMac ? input.meta : input.control;
       if (this.url && this.url.startsWith('https://corporate.symphony.com')) {


### PR DESCRIPTION
## Description
Devtools shortcut fix - DraftJS is considering Ctrl + I as italic without checking for Alt or Shift keys

https://github.com/facebookarchive/draft-js/issues/941

## Related PRs
