### PR TITLE
SDA-4332 & SDA-4359 (Limit toast notification to prevent overlying of call notification)

### DIFF
--- a/src/app/auto-update-handler.ts
+++ b/src/app/auto-update-handler.ts
@@ -257,9 +257,10 @@ export class AutoUpdate {
     const cc = config.getFilteredCloudConfigFields([
       'betaAutoUpdateChannelEnabled',
     ]);
-    this.channelConfigLocation = cc
-      ? ChannelConfigLocation.ACP
-      : ChannelConfigLocation.LOCALFILE;
+    this.channelConfigLocation =
+      'betaAutoUpdateChannelEnabled' in cc && cc.betaAutoUpdateChannelEnabled
+        ? ChannelConfigLocation.ACP
+        : ChannelConfigLocation.LOCALFILE;
 
     this.finalAutoUpdateChannel = autoUpdateChannel;
     this.installVariant = installVariant;

--- a/src/renderer/notification-handler.ts
+++ b/src/renderer/notification-handler.ts
@@ -31,6 +31,7 @@ const NEXT_INSERT_POSITION_WITH_INPUT = 142;
 const NOTIFICATIONS_PADDING_SEPARATION = 12;
 const CALL_NOTIFICATION_WIDTH = 264;
 const CALL_NOTIFICATION_HEIGHT = 286;
+const MAX_VISIBLE_TOAST_FOR_CALL_NOTIFICATION = 3;
 export default class NotificationHandler {
   public settings: ISettings;
   public callNotificationSettings: ICorner = { x: 0, y: 0 };
@@ -150,9 +151,9 @@ export default class NotificationHandler {
     }
     this.calculateDimensions();
     // Maximum amount of Notifications we can show:
-    this.settings.maxVisibleNotifications = Math.floor(
-      display.workAreaSize.height / this.settings.totalHeight,
-    );
+    this.settings.maxVisibleNotifications =
+      Math.floor(display.workAreaSize.height / this.settings.totalHeight) -
+      MAX_VISIBLE_TOAST_FOR_CALL_NOTIFICATION;
   }
 
   /**


### PR DESCRIPTION
## Description
- Limit the number of toast notifications displayed to prevent overlying of call notification
- Displays 3 toast notifications less to give space for call notification
- fix reading cloud-config field `betaAutoUpdateChannelEnabled`