### PR TITLE
SDA-4214: Update Toast notification to use toolbar

### DIFF
--- a/src/renderer/notification.ts
+++ b/src/renderer/notification.ts
@@ -655,6 +655,7 @@ class Notification extends NotificationHandler {
       frame: false,
       transparent: true,
       fullscreenable: false,
+      type: 'toolbar',
       acceptFirstMouse: true,
       title: NOTIFICATION_WINDOW_TITLE,
       webPreferences: {


### PR DESCRIPTION
## Description
Normal windows seem to work unexpectedly on Toast Notification
By using toolbar we can keep the notification config remained intact

## Related PRs
