### PR TITLE
SDA-4370: Switching Pod url will also change about us, remove unnecessary field in config

### DIFF
--- a/spec/aboutApp.spec.ts
+++ b/spec/aboutApp.spec.ts
@@ -6,7 +6,7 @@ import { ipcRenderer } from './__mocks__/electron';
 
 describe('about app', () => {
   const aboutAppDataLabel = 'about-app-data';
-  const aboutDataMock = {
+  const aboutDataMockClipboard = {
     sbeVersion: '1',
     userConfig: {},
     globalConfig: { isPodUrlEditable: true },
@@ -31,6 +31,9 @@ describe('about app', () => {
     httpParserVersion: '11.12',
     swiftSearchVersion: '1.55.3-beta.1',
     swiftSearchSupportedVersion: 'N/A',
+  };
+  const aboutDataMockState = {
+    ...aboutDataMockClipboard,
     updatedHostname: 'N/A',
   };
   const onLabelEvent = 'on';
@@ -60,19 +63,19 @@ describe('about app', () => {
   it('should call `updateState` when component is mounted', () => {
     const spy = jest.spyOn(AboutApp.prototype, 'setState');
     shallow(React.createElement(AboutApp));
-    ipcRenderer.send('about-app-data', aboutDataMock);
-    expect(spy).toBeCalledWith(aboutDataMock);
+    ipcRenderer.send('about-app-data', aboutDataMockState);
+    expect(spy).toBeCalledWith(aboutDataMockState);
   });
 
   it('should copy the correct data on to clipboard', () => {
     const spyIpc = jest.spyOn(ipcRenderer, ipcSendEvent);
     const wrapper = shallow(React.createElement(AboutApp));
-    ipcRenderer.send('about-app-data', aboutDataMock);
+    ipcRenderer.send('about-app-data', aboutDataMockClipboard);
     const copyButtonSelector = `[data-testid="COPY_BUTTON"]`;
     wrapper.find(copyButtonSelector).simulate('click');
     const expectedData = {
       cmd: apiCmds.aboutAppClipBoardData,
-      clipboard: aboutDataMock,
+      clipboard: aboutDataMockClipboard,
       clipboardType: 'clipboard',
     };
     expect(spyIpc).toBeCalledWith('symphony-api', expectedData);
@@ -80,7 +83,7 @@ describe('about app', () => {
 
   it('should display input when triple clicked on pod', () => {
     const wrapper = shallow(React.createElement(AboutApp));
-    ipcRenderer.send('about-app-data', aboutDataMock);
+    ipcRenderer.send('about-app-data', aboutDataMockState);
     const pod = wrapper.find(`[data-testid="POD_INFO"]`);
     pod.simulate('click', { detail: 1 });
     pod.simulate('click', { detail: 2 });
@@ -90,7 +93,7 @@ describe('about app', () => {
   });
 
   it('should not display input when triple clicked on pod', () => {
-    const cloneAboutDataMock = aboutDataMock;
+    const cloneAboutDataMock = aboutDataMockState;
 
     cloneAboutDataMock.globalConfig = { isPodUrlEditable: false };
     cloneAboutDataMock.userConfig = { isPodUrlEditable: true };
@@ -106,7 +109,7 @@ describe('about app', () => {
   });
 
   it('should not display config based on global config only', () => {
-    const cloneAboutDataMock = aboutDataMock;
+    const cloneAboutDataMock = aboutDataMockState;
 
     cloneAboutDataMock.globalConfig = { isPodUrlEditable: false };
     cloneAboutDataMock.userConfig = { isPodUrlEditable: false };
@@ -122,7 +125,7 @@ describe('about app', () => {
   });
 
   it('should display config based on global config only', () => {
-    const cloneAboutDataMock = aboutDataMock;
+    const cloneAboutDataMock = aboutDataMockState;
 
     cloneAboutDataMock.globalConfig = { isPodUrlEditable: true };
     cloneAboutDataMock.userConfig = { isPodUrlEditable: false };

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1277,7 +1277,9 @@ export class WindowHandler {
         ...filteredConfig,
       };
       const host = parse(
-        (userConfig as IConfig).url || (globalConfig as IConfig).url,
+        this.url
+          ? this.url
+          : (userConfig as IConfig).url || (globalConfig as IConfig).url,
       );
       const aboutInfo = {
         userConfig,

--- a/src/renderer/components/about-app.tsx
+++ b/src/renderer/components/about-app.tsx
@@ -37,7 +37,7 @@ interface IState {
   swiftSearchVersion?: string;
   swiftSearchSupportedVersion?: string;
   client?: string;
-  updatedHostname: string;
+  updatedHostname?: string;
   isPodEditing: boolean;
   isValidHostname: boolean;
   didUpdateHostname: boolean;
@@ -231,6 +231,7 @@ export default class AboutApp extends React.Component<{}, IState> {
       ...rest,
     };
     if (data) {
+      delete data.updatedHostname;
       ipcRenderer.send(apiName.symphonyApi, {
         cmd: apiCmds.aboutAppClipBoardData,
         clipboard: data,
@@ -298,7 +299,7 @@ export default class AboutApp extends React.Component<{}, IState> {
    */
   public handlePodInputBlur = (_event) => {
     const { updatedHostname, hostname } = this.state;
-    if (!HOSTNAME_REGEX.test(updatedHostname)) {
+    if (!HOSTNAME_REGEX.test(updatedHostname || '')) {
       this.setState({
         isPodEditing: false,
         isValidHostname: false,


### PR DESCRIPTION
## Description
Backport of https://github.com/finos/SymphonyElectron/pull/1988
but instead it will only has

Adding fix to the issue related to document.location.href changed will make pod url went unchanged
Copy to clipboard will remove updatedHostName


## Related PRs
