### PR TITLE
GitHub - use python version 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
       - name: install linux dependency
         if: startsWith(matrix.os,'ubuntu')
         run: sudo apt-get install libxtst-dev
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.11
       - run: npm install
       - run: npm test
         env:


### PR DESCRIPTION
GitHub actions recently upgraded the Python version on macOS runner https://github.com/actions/runner-images/pull/8695/files#diff-de83d5c5fa69158ec0c3eb7781d321cff841a277a7b393694b3cdbda34df0c9aR30

`distutils` is not present in Python version `3.12` which is required for `ffi-napi`