### PR TITLE
Migrate from altool to notarytool for app notarization

### DIFF
--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -124,7 +124,9 @@ productsign --sign "Developer ID Installer: Symphony Communication Services LLC"
 echo "Signing Package complete: ${PACKAGE}"
 
 # Notarize the app
-xcrun altool --notarize-app --primary-bundle-id "$BUNDLE_ID" --username "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --file $SIGNED_PACKAGE > /tmp/notarize.txt
+# xcrun altool --notarize-app --primary-bundle-id "$pwd" --username "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --file $SIGNED_PACKAGE > /tmp/notarize.txt
+xcrun notarytool submit --apple-id "$APPLE_ID" --password "$APPLE_ID_PASSWORD" --team-id "$TEAM_ID" $SIGNED_PACKAGE --wait > /tmp/notarize.txt
+
 cat /tmp/notarize.txt
 REQUEST_ID=$(sed -n '2p' /tmp/notarize.txt)
 REQUEST_ID=$(echo $REQUEST_ID | cut -d "=" -f 2)


### PR DESCRIPTION
## Description
Migration to notarytool as altool was deprecated: https://developer.apple.com/news/?id=y5mjxqmn

