### PR TITLE
Electron upgrade to 27.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "builder-util-runtime": "^9.0.3",
     "cross-env": "7.0.3",
     "del": "3.0.0",
-    "electron": "^27.1.2",
+    "electron": "27.1.3",
     "electron-builder": "^24.2.1",
     "electron-icon-maker": "0.0.5",
     "electron-osx-sign": "^0.6.0",


### PR DESCRIPTION
## Description
Upgraded Electron to v27.1.3
Security: backported fix for 1491210.
Security: backported fix for CVE-2023-6345
Security: backported fix for CVE-2023-6346.
Security: backported fix for CVE-2023-6347.
Security: backported fix for CVE-2023-6350. #40643 Security: backported fix for CVE-2023-6350. #40648 Updated Chromium to 118.0.5993.159. #40631

## Related PRs
