### PR TITLE
SDA-4429 CVE-2023-6508  CVE-2023-7024 patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@symphony/symphony-c9-shell": "3.29.0-0.98.2.174",
         "@types/lazy-brush": "^1.0.0",
         "archiver": "5.3.1",
         "async.map": "0.5.2",
@@ -41,7 +40,7 @@
         "builder-util-runtime": "^9.0.3",
         "cross-env": "7.0.3",
         "del": "3.0.0",
-        "electron": "27.1.3",
+        "electron": "^27.2.0",
         "electron-builder": "^24.2.1",
         "electron-icon-maker": "0.0.5",
         "electron-osx-sign": "^0.6.0",
@@ -6640,9 +6639,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "27.1.3",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-27.1.3.tgz",
-      "integrity": "sha512-7eD8VMhhlL5J531OOawn00eMthUkX1e3qN5Nqd7eMK8bg5HxQBrn8bdPlvUEnCano9KhrVwaDnGeuzWoDOGpjQ==",
+      "version": "27.2.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-27.2.0.tgz",
+      "integrity": "sha512-no/iMICVLI/5G0IqgKFbB89HDN88DWwKeRO+dPfJPkpJISdEX8Cx/sMEOFuuRa4VNInNe5CKCqRWExK5z3AdcQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -22942,9 +22941,9 @@
       }
     },
     "electron": {
-      "version": "27.1.3",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-27.1.3.tgz",
-      "integrity": "sha512-7eD8VMhhlL5J531OOawn00eMthUkX1e3qN5Nqd7eMK8bg5HxQBrn8bdPlvUEnCano9KhrVwaDnGeuzWoDOGpjQ==",
+      "version": "27.2.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-27.2.0.tgz",
+      "integrity": "sha512-no/iMICVLI/5G0IqgKFbB89HDN88DWwKeRO+dPfJPkpJISdEX8Cx/sMEOFuuRa4VNInNe5CKCqRWExK5z3AdcQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "builder-util-runtime": "^9.0.3",
     "cross-env": "7.0.3",
     "del": "3.0.0",
-    "electron": "27.1.3",
+    "electron": "^27.2.0",
     "electron-builder": "^24.2.1",
     "electron-icon-maker": "0.0.5",
     "electron-osx-sign": "^0.6.0",


### PR DESCRIPTION
## Description

Upgrading electron to [v27.2.0](https://github.com/electron/electron/releases/tag/v27.2.0) to patch 2 vulnerabilities 

[CVE-2023-6508](https://github.com/advisories/GHSA-3pr6-6r34-c98x)

[CVE-2023-7024](https://github.com/advisories/GHSA-7c6v-f3h8-2x89)
