### PR TITLE
SDA-4422 Bug - Workaround for frameless transparent windows title bar being displayed

### DIFF
--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -227,6 +227,16 @@ export const createComponentWindow = (
       browserWindow.show();
     });
   }
+
+  // SDA-4422 workaround
+  if (!options.frame && options.transparent) {
+    browserWindow.on('blur', () => {
+      browserWindow.setBackgroundColor('#00000000');
+    });
+    browserWindow.on('focus', () => {
+      browserWindow.setBackgroundColor('#00000000');
+    });
+  }
   browserWindow.webContents.once('did-finish-load', () => {
     if (!browserWindow || !windowExists(browserWindow)) {
       return;


### PR DESCRIPTION
## Description

Workaround for an electronJS bug: title bar of frameless transparent windows are shown on blur.
