### PR TITLE
RTC-14731 - update "showScreenSharingIndicator" method

### DIFF
--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -313,10 +313,12 @@ export enum NotificationActions {
  * Screen sharing Indicator
  */
 export interface IScreenSharingIndicatorOptions {
+  // id of the display that is being shared
   displayId: string;
+
   requestId: number;
+
   streamId: string;
-  stream?: MediaStream;
 }
 
 export interface IVersionInfo {

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -512,12 +512,9 @@ export class SSFApi {
   }
 
   /**
-   * Shows a banner that informs user that the screen is being shared.
+   * Shows a banner that informs the user that the screen is being shared.
    *
-   * @param options object with following fields:
-   *    - stream https://developer.mozilla.org/en-US/docs/Web/API/MediaStream/MediaStream object.
-   *             The indicator automatically destroys itself when stream becomes inactive (see MediaStream.active).
-   *    - displayId id of the display that is being shared or that contains the shared app
+   * @param options
    * @param callback callback function that will be called to handle events.
    * Callback receives event object { type: string }. Types:
    *    - 'error' - error occured. Event object contains 'reason' field.
@@ -527,23 +524,17 @@ export class SSFApi {
     options: IScreenSharingIndicatorOptions,
     callback,
   ): void {
-    const { displayId, stream } = options;
+    const { displayId, streamId } = options;
 
-    if (!stream || !stream.active || stream.getVideoTracks().length !== 1) {
-      callback({ type: 'error', reason: 'bad stream' });
+    if (streamId && typeof streamId !== 'string') {
+      callback({ type: 'error', reason: 'bad streamId' });
       return;
     }
+
     if (displayId && typeof displayId !== 'string') {
       callback({ type: 'error', reason: 'bad displayId' });
       return;
     }
-
-    const destroy = () => {
-      throttledCloseScreenShareIndicator(stream.id);
-      stream.removeEventListener('inactive', destroy);
-    };
-
-    stream.addEventListener('inactive', destroy);
 
     if (typeof callback === 'function') {
       local.screenSharingIndicatorCallback = callback;
@@ -551,7 +542,7 @@ export class SSFApi {
         cmd: apiCmds.openScreenSharingIndicator,
         displayId,
         id: ++nextIndicatorId,
-        streamId: stream.id,
+        streamId,
       });
     }
   }


### PR DESCRIPTION
`showScreenSharingIndicator` is a method used by Symphony Meetings. However, when we switched from Client 1.5 to 2.0, the window object for SymphonyElectron changed name and we haven't used this method in about 3 years. However, I am investigating https://perzoinc.atlassian.net/browse/RTC-14615 about screen sharing issues and one possible explanation is that our current way of sharing screen by posting messages via `window.postMessage` disappears or don't get picked up. Therefore we should look into using the exposed SymphonyElectron methods via the window object. It could be more reliable.