### PR TITLE
SDA-4453 - Memory leak issue on snipping tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "builder-util-runtime": "^9.0.3",
     "cross-env": "7.0.3",
     "del": "3.0.0",
-    "electron": "^27.2.2",
+    "electron": "^27.2.3",
     "electron-builder": "^24.2.1",
     "electron-icon-maker": "0.0.5",
     "electron-osx-sign": "^0.6.0",

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -1439,7 +1439,6 @@ export class WindowHandler {
     ) {
       opts.alwaysOnTop = true;
     }
-
     const areWindowsRestoredPostHide =
       (winStore.windowsRestored && this.hideOnCapture) || !this.hideOnCapture;
 
@@ -1512,6 +1511,8 @@ export class WindowHandler {
       logger.info(
         'window-handler: createSnippingToolWindow: Closing snipping window, attempting to delete temp snip image',
       );
+      ipcMain.removeAllListeners(ScreenShotAnnotation.CLOSE);
+      ipcMain.removeAllListeners(ScreenShotAnnotation.UPLOAD);
       ipcMain.removeAllListeners(ScreenShotAnnotation.COPY_TO_CLIPBOARD);
       ipcMain.removeAllListeners(ScreenShotAnnotation.SAVE_AS);
       this.snippingToolWindow?.close();

--- a/src/common/ipcEvent.ts
+++ b/src/common/ipcEvent.ts
@@ -2,4 +2,5 @@ export enum ScreenShotAnnotation {
   COPY_TO_CLIPBOARD = 'copy-to-clipboard',
   SAVE_AS = 'save-as',
   CLOSE = 'close-snippet',
+  UPLOAD = 'upload-snippet',
 }

--- a/src/renderer/components/snipping-tool.tsx
+++ b/src/renderer/components/snipping-tool.tsx
@@ -281,7 +281,10 @@ const SnippingTool: React.FunctionComponent<ISnippingToolProps> = ({
       AnalyticsElements.SCREEN_CAPTURE_ANNOTATE,
       ScreenSnippetActionTypes.ANNOTATE_ADD,
     );
-    ipcRenderer.send('upload-snippet', { screenSnippetPath, mergedImageData });
+    ipcRenderer.send(ScreenShotAnnotation.UPLOAD, {
+      screenSnippetPath,
+      mergedImageData,
+    });
   };
 
   const onClose = async () => {


### PR DESCRIPTION
## Description
Snipping tool "close" and "upload" event handlers were being registered every time we created the snipping tool window, causing a memory leak issue + focus issues --> the window in question may have been destroyed in case we created/destroyed the child window that registered these handlers.

Also took the opportunity to upgrade electron to get the fix for CVE-2024-0518 and CVE-2024-0519