### PR TITLE
SDA-4459 (Apply latest or beta channel based on user entitlement)

### DIFF
--- a/.run/Demo (Build & Run).run.xml
+++ b/.run/Demo (Build & Run).run.xml
@@ -1,7 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Demo (Build &amp; Run)" type="NodeJSConfigurationType" application-parameters=". --url=file://$PROJECT_DIR$/src/demo/index.html" path-to-node="$PROJECT_DIR$/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron" working-dir="$PROJECT_DIR$">
     <envs>
-      <env name="ELECTRON_FORCE_IS_PACKAGED" value="true" />
       <env name="ELECTRON_DEBUGGING" value="true" />
     </envs>
     <method v="2">

--- a/config/Symphony.config
+++ b/config/Symphony.config
@@ -45,5 +45,6 @@
     "autoLaunchPath": "",
     "userDataPath": "",
     "chromeFlags": "",
-    "betaAutoUpdateChannelEnabled": true
+    "betaAutoUpdateChannelEnabled": true,
+    "latestAutoUpdateChannelEnabled": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symphony",
-  "version": "24.2.0",
+  "version": "24.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symphony",
-      "version": "24.2.0",
+      "version": "24.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -40,7 +40,7 @@
         "builder-util-runtime": "^9.0.3",
         "cross-env": "7.0.3",
         "del": "3.0.0",
-        "electron": "^28.1.3",
+        "electron": "^28.2.0",
         "electron-builder": "^24.2.1",
         "electron-icon-maker": "0.0.5",
         "electron-osx-sign": "^0.6.0",
@@ -6633,9 +6633,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "28.1.3",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-28.1.3.tgz",
-      "integrity": "sha512-NSFyTo6SndTPXzU18XRePv4LnjmuM9rF5GMKta1/kPmi02ISoSRonnD7wUlWXD2x53XyJ6d/TbSVesMW6sXkEQ==",
+      "version": "28.2.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-28.2.0.tgz",
+      "integrity": "sha512-22SylXQQ9IHtwLw4D+Z4Si7OUpeDtpHfJVTjy3yv53iLg5zJKKPOCWT4ZwgYGHQZ0eldyBrYBHF/P9FPd2CcVQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -22991,9 +22991,9 @@
       }
     },
     "electron": {
-      "version": "28.1.3",
-      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-28.1.3.tgz",
-      "integrity": "sha512-NSFyTo6SndTPXzU18XRePv4LnjmuM9rF5GMKta1/kPmi02ISoSRonnD7wUlWXD2x53XyJ6d/TbSVesMW6sXkEQ==",
+      "version": "28.2.0",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/electron/-/electron-28.2.0.tgz",
+      "integrity": "sha512-22SylXQQ9IHtwLw4D+Z4Si7OUpeDtpHfJVTjy3yv53iLg5zJKKPOCWT4ZwgYGHQZ0eldyBrYBHF/P9FPd2CcVQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -86,6 +86,8 @@ const menuItemConfigFields = [
   'isAutoUpdateEnabled',
   'enableBrowserLogin',
   'forceAutoUpdate',
+  'betaAutoUpdateChannelEnabled',
+  'latestAutoUpdateChannelEnabled',
 ];
 
 let {
@@ -99,6 +101,8 @@ let {
   isAutoUpdateEnabled,
   enableBrowserLogin,
   forceAutoUpdate,
+  betaAutoUpdateChannelEnabled,
+  latestAutoUpdateChannelEnabled,
 } = config.getConfigFields(menuItemConfigFields) as IConfig;
 let initialAnalyticsSent = false;
 const CORP_URL = 'https://corporate.symphony.com';
@@ -246,6 +250,8 @@ export class AppMenu {
     isAutoUpdateEnabled = configData.isAutoUpdateEnabled;
     enableBrowserLogin = configData.enableBrowserLogin;
     forceAutoUpdate = configData.forceAutoUpdate;
+    betaAutoUpdateChannelEnabled = configData.betaAutoUpdateChannelEnabled;
+    latestAutoUpdateChannelEnabled = configData.latestAutoUpdateChannelEnabled;
     // fetch updated cloud config
     this.cloudConfig = config.getFilteredCloudConfigFields(
       this.menuItemConfigFields,
@@ -312,7 +318,10 @@ export class AppMenu {
           },
           visible:
             isMac &&
-            !!(isAutoUpdateEnabled || forceAutoUpdate) &&
+            !!(
+              (isAutoUpdateEnabled || forceAutoUpdate) &&
+              (betaAutoUpdateChannelEnabled || latestAutoUpdateChannelEnabled)
+            ) &&
             !!windowHandler.isMana,
           label: i18n.t('Check for updates')(),
         },
@@ -714,7 +723,10 @@ export class AppMenu {
           },
           visible:
             isWindowsOS &&
-            !!(isAutoUpdateEnabled || forceAutoUpdate) &&
+            !!(
+              (isAutoUpdateEnabled || forceAutoUpdate) &&
+              (betaAutoUpdateChannelEnabled || latestAutoUpdateChannelEnabled)
+            ) &&
             !!windowHandler.isMana,
           label: i18n.t('Check for updates')(),
         },

--- a/src/app/auto-update-handler.ts
+++ b/src/app/auto-update-handler.ts
@@ -251,32 +251,9 @@ export class AutoUpdate {
       'latestAutoUpdateChannelEnabled',
     ]);
 
-    const cc = config.getFilteredCloudConfigFields([
-      'betaAutoUpdateChannelEnabled',
-    ]) as IConfig;
-    this.channelConfigLocation =
-      Object.keys(cc).length === 0 || cc.betaAutoUpdateChannelEnabled
-        ? ChannelConfigLocation.ACP
-        : ChannelConfigLocation.LOCALFILE;
-
-    this.finalAutoUpdateChannel = betaAutoUpdateChannelEnabled
-      ? UpdateChannel.BETA
-      : autoUpdateChannel;
+    this.channelConfigLocation = ChannelConfigLocation.LOCALFILE;
+    this.finalAutoUpdateChannel = autoUpdateChannel;
     this.installVariant = installVariant;
-    if (isWindowsOS) {
-      await retrieveWindowsRegistry();
-      const registryAutoUpdate = RegistryStore.getRegistry();
-      const identifiedChannelFromRegistry = [
-        EChannelRegistry.BETA,
-        EChannelRegistry.LATEST,
-      ].includes(registryAutoUpdate.currentChannel)
-        ? registryAutoUpdate.currentChannel
-        : '';
-      if (identifiedChannelFromRegistry) {
-        this.finalAutoUpdateChannel = identifiedChannelFromRegistry;
-        this.channelConfigLocation = ChannelConfigLocation.REGISTRY;
-      }
-    }
 
     const pmp = config.getFilteredCloudConfigFields([
       'sdaInstallerMsiUrlEnabledVisible',
@@ -304,6 +281,22 @@ export class AutoUpdate {
         this.finalAutoUpdateChannel = UpdateChannel.BETA;
       }
       this.channelConfigLocation = ChannelConfigLocation.ACP;
+    }
+
+    // Registry has higher priority
+    if (isWindowsOS) {
+      await retrieveWindowsRegistry();
+      const registryAutoUpdate = RegistryStore.getRegistry();
+      const identifiedChannelFromRegistry = [
+        EChannelRegistry.BETA,
+        EChannelRegistry.LATEST,
+      ].includes(registryAutoUpdate.currentChannel)
+        ? registryAutoUpdate.currentChannel
+        : '';
+      if (identifiedChannelFromRegistry) {
+        this.finalAutoUpdateChannel = identifiedChannelFromRegistry;
+        this.channelConfigLocation = ChannelConfigLocation.REGISTRY;
+      }
     }
   };
 }

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -71,8 +71,11 @@ export interface IConfig {
   enableBrowserLogin?: boolean;
   browserLoginAutoConnect?: boolean;
   betaAutoUpdateChannelEnabled?: boolean;
+  latestAutoUpdateChannelEnabled?: boolean;
   forceAutoUpdate?: boolean;
   isPodUrlEditable?: boolean;
+  sdaInstallerMsiUrlEnabledVisible?: boolean;
+  sdaInstallerMsiUrlBetaEnabledVisible?: boolean;
 }
 
 export interface IGlobalConfig {
@@ -123,6 +126,8 @@ export interface IPMPEntitlements {
   memoryRefresh: CloudConfigDataTypes;
   refreshAppThreshold: CloudConfigDataTypes;
   disableThrottling: CloudConfigDataTypes;
+  sdaInstallerMsiUrlEnabledVisible: boolean;
+  sdaInstallerMsiUrlBetaEnabledVisible: boolean;
 }
 
 export interface IPermission {

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -1090,6 +1090,8 @@ export const updateFeaturesForCloudConfig = async (
     isAutoUpdateEnabled,
     autoUpdateCheckInterval,
     forceAutoUpdate,
+    betaAutoUpdateChannelEnabled,
+    latestAutoUpdateChannelEnabled,
   } = config.getConfigFields([
     'launchOnStartup',
     'alwaysOnTop',
@@ -1098,6 +1100,8 @@ export const updateFeaturesForCloudConfig = async (
     'isAutoUpdateEnabled',
     'autoUpdateCheckInterval',
     'forceAutoUpdate',
+    'betaAutoUpdateChannelEnabled',
+    'latestAutoUpdateChannelEnabled',
   ]) as IConfig;
 
   const mainWebContents = windowHandler.getMainWebContents();
@@ -1149,7 +1153,10 @@ export const updateFeaturesForCloudConfig = async (
 
   // SDA auto updater
   logger.info(`window-utils: initiate auto update?`, isAutoUpdateEnabled);
-  if (forceAutoUpdate || isAutoUpdateEnabled) {
+  if (
+    (forceAutoUpdate || isAutoUpdateEnabled) &&
+    (betaAutoUpdateChannelEnabled || latestAutoUpdateChannelEnabled)
+  ) {
     if (!autoUpdateIntervalId) {
       // randomised to avoid having all users getting SDA update at the same time
       autoUpdateIntervalId = setInterval(async () => {


### PR DESCRIPTION
## Description
- Apply the latest or beta channel based on user entitlement

PMP - sda-auto-update 🛑 - Auto update disabled

PMP - sda-auto-update 🟢 - Entitlement Visibility 🛑 - Latest Channel

PMP - sda-auto-update 🟢 - Entitlement Visibility 🟢 - Check for User Entitlements as below
| Setting  | Channel |
| ------------- | ------------- |
| User Entitlement 🟢 User Entitlement Beta 🟢 | Beta Channel  |
| User Entitlement 🛑 User Entitlement Beta 🛑 | Auto Update Diabled 🛑 |
| User Entitlement 🟢 User Entitlement Beta 🛑 | Latest Channel |
| User Entitlement 🛑 User Entitlement Beta 🟢 | Beta Channel |


-----

User Entitlement = `latestAutoUpdateChannelEnabled`
User Entitlement Beta = `betaAutoUpdateChannelEnabled`

------

Entitlement Visibility = `sdaInstallerMsiUrlEnabledVisible || sdaInstallerMsiUrlBetaEnabledVisible`

------

## Related PRs
[SFE-Lite](https://github.com/SymphonyOSF/SFE-Lite/pull/16569)
[BFF](https://github.com/SymphonyOSF/BFF/pull/1040)