### PR TITLE
SDA-4472 (Migrate Symphony.config & installVariant into /Library/Preference)

### DIFF
--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -7,59 +7,108 @@ plistFileName="com.symphony.electron-desktop.plist"
 userName=$(stat -f%Su /dev/console)
 plistFilePath="/Users/$userName/Library/Preferences/$plistFileName"
 
-echo $plistFilePath
-echo $userName
+echo "$plistFilePath"
+echo "$userName"
+echo "$EUID"
 
 # Create a plist file it not exist
-if [ ! -f $plistFilePath ]
+if [ ! -f "$plistFilePath" ]
 then
   # Add a default entry
   echo "Plist file does not exists creating new file"
-  sudo -u $userName defaults write $plistFilePath ApplicationName Symphony
+  if [ "$EUID" -ne 0 ]; then
+    defaults write "$plistFilePath" ApplicationName Symphony
+  else
+    sudo -u "$userName" defaults write "$plistFilePath" ApplicationName Symphony
+  fi
 fi
 
 #Set default value
-sudo -u $userName defaults write $plistFilePath url -string "https://my.symphony.com"
-sudo -u $userName defaults write $plistFilePath autoUpdateUrl -string ""
-sudo -u $userName defaults write $plistFilePath autoUpdateChannel -string "latest"
-sudo -u $userName defaults write $plistFilePath isAutoUpdateEnabled -bool true
-sudo -u $userName defaults write $plistFilePath isPodUrlEditable -bool true
-sudo -u $userName defaults write $plistFilePath forceAutoUpdate -bool false
-sudo -u $userName defaults write $plistFilePath autoUpdateCheckInterval -string "30"
-sudo -u $userName defaults write $plistFilePath enableBrowserLogin -bool false
-sudo -u $userName defaults write $plistFilePath browserLoginAutoConnect -bool false
-sudo -u $userName defaults write $plistFilePath overrideUserAgent -bool false
-sudo -u $userName defaults write $plistFilePath minimizeOnClose -string "ENABLED"
-sudo -u $userName defaults write $plistFilePath launchOnStartup -string "ENABLED"
-sudo -u $userName defaults write $plistFilePath alwaysOnTop -string "DISABLED"
-sudo -u $userName defaults write $plistFilePath bringToFront -string "DISABLED"
-sudo -u $userName defaults write $plistFilePath whitelistUrl -string "*"
-sudo -u $userName defaults write $plistFilePath isCustomTitleBar -string "ENABLED"
-sudo -u $userName defaults write $plistFilePath memoryRefresh -string "ENABLED"
-sudo -u $userName defaults write $plistFilePath memoryThreshold -string "800"
-sudo -u $userName defaults write $plistFilePath devToolsEnabled -bool true
-sudo -u $userName defaults write $plistFilePath contextIsolation -bool true
-sudo -u $userName defaults write $plistFilePath contextOriginUrl -string ""
-sudo -u $userName defaults write $plistFilePath disableGpu -bool false
-sudo -u $userName defaults write $plistFilePath enableRendererLogs -bool false
-sudo -u $userName defaults write $plistFilePath ctWhitelist -array
-sudo -u $userName defaults write $plistFilePath podWhitelist -array
-sudo -u $userName defaults write $plistFilePath position -string "upper-right"
-sudo -u $userName defaults write $plistFilePath display -string ""
-sudo -u $userName defaults write $plistFilePath authServerWhitelist -string ""
-sudo -u $userName defaults write $plistFilePath authNegotiateDelegateWhitelist -string ""
-sudo -u $userName defaults write $plistFilePath disableThrottling -string "DISABLED"
-sudo -u $userName defaults write $plistFilePath media -bool true
-sudo -u $userName defaults write $plistFilePath geolocation -bool true
-sudo -u $userName defaults write $plistFilePath notifications -bool true
-sudo -u $userName defaults write $plistFilePath midiSysex -bool true
-sudo -u $userName defaults write $plistFilePath pointerLock -bool true
-sudo -u $userName defaults write $plistFilePath fullscreen -bool true
-sudo -u $userName defaults write $plistFilePath openExternal -bool true
-sudo -u $userName defaults write $plistFilePath autoLaunchPath -string ""
-sudo -u $userName defaults write $plistFilePath userDataPath -string ""
-sudo -u $userName defaults write $plistFilePath chromeFlags -string ""
-sudo -u $userName defaults write $plistFilePath betaAutoUpdateChannelEnabled -bool true
+if [ "$EUID" -ne 0 ]; then
+  defaults write "$plistFilePath" url -string "https://my.symphony.com"
+  defaults write "$plistFilePath" autoUpdateUrl -string ""
+  defaults write "$plistFilePath" autoUpdateChannel -string "latest"
+  defaults write "$plistFilePath" isAutoUpdateEnabled -bool true
+  defaults write "$plistFilePath" isPodUrlEditable -bool true
+  defaults write "$plistFilePath" forceAutoUpdate -bool false
+  defaults write "$plistFilePath" autoUpdateCheckInterval -string "30"
+  defaults write "$plistFilePath" enableBrowserLogin -bool false
+  defaults write "$plistFilePath" browserLoginAutoConnect -bool false
+  defaults write "$plistFilePath" overrideUserAgent -bool false
+  defaults write "$plistFilePath" minimizeOnClose -string "ENABLED"
+  defaults write "$plistFilePath" launchOnStartup -string "ENABLED"
+  defaults write "$plistFilePath" alwaysOnTop -string "DISABLED"
+  defaults write "$plistFilePath" bringToFront -string "DISABLED"
+  defaults write "$plistFilePath" whitelistUrl -string "*"
+  defaults write "$plistFilePath" isCustomTitleBar -string "ENABLED"
+  defaults write "$plistFilePath" memoryRefresh -string "ENABLED"
+  defaults write "$plistFilePath" memoryThreshold -string "800"
+  defaults write "$plistFilePath" devToolsEnabled -bool true
+  defaults write "$plistFilePath" contextIsolation -bool true
+  defaults write "$plistFilePath" contextOriginUrl -string ""
+  defaults write "$plistFilePath" disableGpu -bool false
+  defaults write "$plistFilePath" enableRendererLogs -bool false
+  defaults write "$plistFilePath" ctWhitelist -array
+  defaults write "$plistFilePath" podWhitelist -array
+  defaults write "$plistFilePath" position -string "upper-right"
+  defaults write "$plistFilePath" display -string ""
+  defaults write "$plistFilePath" authServerWhitelist -string ""
+  defaults write "$plistFilePath" authNegotiateDelegateWhitelist -string ""
+  defaults write "$plistFilePath" disableThrottling -string "DISABLED"
+  defaults write "$plistFilePath" media -bool true
+  defaults write "$plistFilePath" geolocation -bool true
+  defaults write "$plistFilePath" notifications -bool true
+  defaults write "$plistFilePath" midiSysex -bool true
+  defaults write "$plistFilePath" pointerLock -bool true
+  defaults write "$plistFilePath" fullscreen -bool true
+  defaults write "$plistFilePath" openExternal -bool true
+  defaults write "$plistFilePath" autoLaunchPath -string ""
+  defaults write "$plistFilePath" userDataPath -string ""
+  defaults write "$plistFilePath" chromeFlags -string ""
+  defaults write "$plistFilePath" betaAutoUpdateChannelEnabled -bool true
+else
+  sudo -u "$userName" defaults write "$plistFilePath" url -string "https://my.symphony.com"
+  sudo -u "$userName" defaults write "$plistFilePath" autoUpdateUrl -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" autoUpdateChannel -string "latest"
+  sudo -u "$userName" defaults write "$plistFilePath" isAutoUpdateEnabled -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" isPodUrlEditable -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" forceAutoUpdate -bool false
+  sudo -u "$userName" defaults write "$plistFilePath" autoUpdateCheckInterval -string "30"
+  sudo -u "$userName" defaults write "$plistFilePath" enableBrowserLogin -bool false
+  sudo -u "$userName" defaults write "$plistFilePath" browserLoginAutoConnect -bool false
+  sudo -u "$userName" defaults write "$plistFilePath" overrideUserAgent -bool false
+  sudo -u "$userName" defaults write "$plistFilePath" minimizeOnClose -string "ENABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" launchOnStartup -string "ENABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" alwaysOnTop -string "DISABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" bringToFront -string "DISABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" whitelistUrl -string "*"
+  sudo -u "$userName" defaults write "$plistFilePath" isCustomTitleBar -string "ENABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" memoryRefresh -string "ENABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" memoryThreshold -string "800"
+  sudo -u "$userName" defaults write "$plistFilePath" devToolsEnabled -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" contextIsolation -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" contextOriginUrl -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" disableGpu -bool false
+  sudo -u "$userName" defaults write "$plistFilePath" enableRendererLogs -bool false
+  sudo -u "$userName" defaults write "$plistFilePath" ctWhitelist -array
+  sudo -u "$userName" defaults write "$plistFilePath" podWhitelist -array
+  sudo -u "$userName" defaults write "$plistFilePath" position -string "upper-right"
+  sudo -u "$userName" defaults write "$plistFilePath" display -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" authServerWhitelist -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" authNegotiateDelegateWhitelist -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" disableThrottling -string "DISABLED"
+  sudo -u "$userName" defaults write "$plistFilePath" media -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" geolocation -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" notifications -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" midiSysex -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" pointerLock -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" fullscreen -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" openExternal -bool true
+  sudo -u "$userName" defaults write "$plistFilePath" autoLaunchPath -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" userDataPath -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" chromeFlags -string ""
+  sudo -u "$userName" defaults write "$plistFilePath" betaAutoUpdateChannelEnabled -bool true
+fi
 
 ## Get Symphony Settings from the temp file ##
 pod_url=$(sed -n '1p' ${settingsFilePath});
@@ -87,25 +136,25 @@ pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 context_origin_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$context_origin_url")
 
 ## Replace the default settings with the user selected settings ##
-plutil -replace url -string $pod_url_escaped $plistFilePath
-plutil -replace contextOriginUrl -string $context_origin_url_escaped $plistFilePath
-plutil -replace minimizeOnClose -string $minimize_on_close $plistFilePath
-plutil -replace alwaysOnTop -string $always_on_top $plistFilePath
-plutil -replace launchOnStartup -string $launch_on_startup $plistFilePath
-plutil -replace bringToFront -string $bring_to_front $plistFilePath
-plutil -replace devToolsEnabled -bool $dev_tools_enabled $plistFilePath
-plutil -replace enableBrowserLogin -bool $enable_browser_login $plistFilePath
-plutil -replace browserLoginAutoConnect -bool $browser_login_autoconnect $plistFilePath
+plutil -replace url -string "$pod_url_escaped" "$plistFilePath"
+plutil -replace contextOriginUrl -string "$context_origin_url_escaped" "$plistFilePath"
+plutil -replace minimizeOnClose -string "$minimize_on_close" "$plistFilePath"
+plutil -replace alwaysOnTop -string "$always_on_top" "$plistFilePath"
+plutil -replace launchOnStartup -string "$launch_on_startup" "$plistFilePath"
+plutil -replace bringToFront -string "$bring_to_front" "$plistFilePath"
+plutil -replace devToolsEnabled -bool "$dev_tools_enabled" "$plistFilePath"
+plutil -replace enableBrowserLogin -bool "$enable_browser_login" "$plistFilePath"
+plutil -replace browserLoginAutoConnect -bool "$browser_login_autoconnect" "$plistFilePath"
 
 ## Add settings force auto update
 force_auto_update=$(sed -n '10p' ${settingsFilePath});
 if [ "$force_auto_update" = "" ]; then force_auto_update=false; fi
-plutil -replace forceAutoUpdate -bool $force_auto_update $plistFilePath
+plutil -replace forceAutoUpdate -bool "$force_auto_update" "$plistFilePath"
 
 ## Add settings is pod url editable
 is_pod_url_editable=$(sed -n '11p' ${settingsFilePath});
 if [ "$is_pod_url_editable" = "" ]; then is_pod_url_editable=true; fi
-plutil -replace isPodUrlEditable -bool $is_pod_url_editable $plistFilePath
+plutil -replace isPodUrlEditable -bool "$is_pod_url_editable" "$plistFilePath"
 
 ## Get Symphony Permissions from the temp file ##
 media=$(sed -n '1p' ${permissionsFilePath});
@@ -126,17 +175,17 @@ if [ "$full_screen" = "" ]; then full_screen=true; fi
 if [ "$open_external_app" = "" ]; then open_external_app=true; fi
 
 ## Replace the default permissions with the user selected permissions ##
-plutil -replace media -bool $media $plistFilePath
-plutil -replace geolocation -bool $geo_location $plistFilePath
-plutil -replace notifications -bool $notifications $plistFilePath
-plutil -replace midiSysex -bool $midi_sysex $plistFilePath
-plutil -replace pointerLock -bool $pointer_lock $plistFilePath
-plutil -replace fullscreen -bool $full_screen $plistFilePath
-plutil -replace openExternal -bool $open_external_app $plistFilePath
+plutil -replace media -bool "$media" "$plistFilePath"
+plutil -replace geolocation -bool "$geo_location" "$plistFilePath"
+plutil -replace notifications -bool "$notifications" "$plistFilePath"
+plutil -replace midiSysex -bool "$midi_sysex" "$plistFilePath"
+plutil -replace pointerLock -bool "$pointer_lock" "$plistFilePath"
+plutil -replace fullscreen -bool "$full_screen" "$plistFilePath"
+plutil -replace openExternal -bool "$open_external_app" "$plistFilePath"
 
 ## Remove the temp settings & permissions file created ##
-rm -f ${settingsFilePath}
-rm -f ${permissionsFilePath}
+# rm -f ${settingsFilePath}
+# rm -f ${permissionsFilePath}
 
 uuid=$(uuidgen)
-plutil -replace installVariant -string $uuid $plistFilePath
+plutil -replace installVariant -string "$uuid" "$plistFilePath"

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -135,8 +135,8 @@ plutil -replace fullscreen -bool $full_screen $plistFilePath
 plutil -replace openExternal -bool $open_external_app $plistFilePath
 
 ## Remove the temp settings & permissions file created ##
-# rm -f ${settingsFilePath}
-# rm -f ${permissionsFilePath}
+rm -f ${settingsFilePath}
+rm -f ${permissionsFilePath}
 
 uuid=$(uuidgen)
 plutil -replace installVariant -string $uuid $plistFilePath

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -87,25 +87,25 @@ pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 context_origin_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$context_origin_url")
 
 ## Replace the default settings with the user selected settings ##
-plutil -replace url -string "${pod_url_escaped}" $plistFilePath
-plutil -replace contextOriginUrl -string "${context_origin_url_escaped}" $plistFilePath
-plutil -replace minimizeOnClose -string "${minimize_on_close}" $plistFilePath
-plutil -replace alwaysOnTop -string "${always_on_top}" $plistFilePath
-plutil -replace launchOnStartup -string "${launch_on_startup}" $plistFilePath
-plutil -replace bringToFront -string "${bring_to_front}" $plistFilePath
-plutil -replace devToolsEnabled -bool "${dev_tools_enabled}" $plistFilePath
-plutil -replace enableBrowserLogin -bool "${enable_browser_login}" $plistFilePath
-plutil -replace browserLoginAutoConnect -bool "${browser_login_autoconnect}" $plistFilePath
+plutil -replace url -string $pod_url_escaped $plistFilePath
+plutil -replace contextOriginUrl -string $context_origin_url_escaped $plistFilePath
+plutil -replace minimizeOnClose -string $minimize_on_close $plistFilePath
+plutil -replace alwaysOnTop -string $always_on_top $plistFilePath
+plutil -replace launchOnStartup -string $launch_on_startup $plistFilePath
+plutil -replace bringToFront -string $bring_to_front $plistFilePath
+plutil -replace devToolsEnabled -bool $dev_tools_enabled $plistFilePath
+plutil -replace enableBrowserLogin -bool $enable_browser_login $plistFilePath
+plutil -replace browserLoginAutoConnect -bool $browser_login_autoconnect $plistFilePath
 
 ## Add settings force auto update
 force_auto_update=$(sed -n '10p' ${settingsFilePath});
 if [ "$force_auto_update" = "" ]; then force_auto_update=false; fi
-plutil -replace forceAutoUpdate -bool "${force_auto_update}" $plistFilePath
+plutil -replace forceAutoUpdate -bool $force_auto_update $plistFilePath
 
 ## Add settings is pod url editable
 is_pod_url_editable=$(sed -n '11p' ${settingsFilePath});
 if [ "$is_pod_url_editable" = "" ]; then is_pod_url_editable=true; fi
-plutil -replace isPodUrlEditable -bool "${is_pod_url_editable}" $plistFilePath
+plutil -replace isPodUrlEditable -bool $is_pod_url_editable $plistFilePath
 
 ## Get Symphony Permissions from the temp file ##
 media=$(sed -n '1p' ${permissionsFilePath});
@@ -126,16 +126,17 @@ if [ "$full_screen" = "" ]; then full_screen=true; fi
 if [ "$open_external_app" = "" ]; then open_external_app=true; fi
 
 ## Replace the default permissions with the user selected permissions ##
-plutil -replace media -bool "${media}" $plistFilePath
-plutil -replace geolocation -bool "${geo_location}" $plistFilePath
-plutil -replace notifications -bool "${notifications}" $plistFilePath
-plutil -replace midiSysex -bool "${midi_sysex}" $plistFilePath
-plutil -replace pointerLock -bool "${pointer_lock}" $plistFilePath
-plutil -replace fullscreen -bool "${full_screen}" $plistFilePath
-plutil -replace openExternal -bool "${open_external_app}" $plistFilePath
+plutil -replace media -bool $media $plistFilePath
+plutil -replace geolocation -bool $geo_location $plistFilePath
+plutil -replace notifications -bool $notifications $plistFilePath
+plutil -replace midiSysex -bool $midi_sysex $plistFilePath
+plutil -replace pointerLock -bool $pointer_lock $plistFilePath
+plutil -replace fullscreen -bool $full_screen $plistFilePath
+plutil -replace openExternal -bool $open_external_app $plistFilePath
 
 ## Remove the temp settings & permissions file created ##
-rm -f ${settingsFilePath}
-rm -f ${permissionsFilePath}
+# rm -f ${settingsFilePath}
+# rm -f ${permissionsFilePath}
 
-plutil -replace installVariant -string "${uuidgen}" $plistFilePath
+uuid=$(uuidgen)
+plutil -replace installVariant -string $uuid $plistFilePath

--- a/installer/mac/postinstall.sh
+++ b/installer/mac/postinstall.sh
@@ -3,11 +3,63 @@
 ## Create file path variables ##
 settingsFilePath='/tmp/sym_settings.txt'
 permissionsFilePath='/tmp/sym_permissions.txt'
-installPath="$2"
-configPath="/Symphony.app/Contents/config"
-configFilePath="${installPath}${configPath}/Symphony.config"
-installVariantPath="${installPath}${configPath}/InstallVariant.info"
-newPath=${configFilePath}
+plistFileName="com.symphony.electron-desktop.plist"
+userName=$(stat -f%Su /dev/console)
+plistFilePath="/Users/$userName/Library/Preferences/$plistFileName"
+
+echo $plistFilePath
+echo $userName
+
+# Create a plist file it not exist
+if [ ! -f $plistFilePath ]
+then
+  # Add a default entry
+  echo "Plist file does not exists creating new file"
+  sudo -u $userName defaults write $plistFilePath ApplicationName Symphony
+fi
+
+#Set default value
+sudo -u $userName defaults write $plistFilePath url -string "https://my.symphony.com"
+sudo -u $userName defaults write $plistFilePath autoUpdateUrl -string ""
+sudo -u $userName defaults write $plistFilePath autoUpdateChannel -string "latest"
+sudo -u $userName defaults write $plistFilePath isAutoUpdateEnabled -bool true
+sudo -u $userName defaults write $plistFilePath isPodUrlEditable -bool true
+sudo -u $userName defaults write $plistFilePath forceAutoUpdate -bool false
+sudo -u $userName defaults write $plistFilePath autoUpdateCheckInterval -string "30"
+sudo -u $userName defaults write $plistFilePath enableBrowserLogin -bool false
+sudo -u $userName defaults write $plistFilePath browserLoginAutoConnect -bool false
+sudo -u $userName defaults write $plistFilePath overrideUserAgent -bool false
+sudo -u $userName defaults write $plistFilePath minimizeOnClose -string "ENABLED"
+sudo -u $userName defaults write $plistFilePath launchOnStartup -string "ENABLED"
+sudo -u $userName defaults write $plistFilePath alwaysOnTop -string "DISABLED"
+sudo -u $userName defaults write $plistFilePath bringToFront -string "DISABLED"
+sudo -u $userName defaults write $plistFilePath whitelistUrl -string "*"
+sudo -u $userName defaults write $plistFilePath isCustomTitleBar -string "ENABLED"
+sudo -u $userName defaults write $plistFilePath memoryRefresh -string "ENABLED"
+sudo -u $userName defaults write $plistFilePath memoryThreshold -string "800"
+sudo -u $userName defaults write $plistFilePath devToolsEnabled -bool true
+sudo -u $userName defaults write $plistFilePath contextIsolation -bool true
+sudo -u $userName defaults write $plistFilePath contextOriginUrl -string ""
+sudo -u $userName defaults write $plistFilePath disableGpu -bool false
+sudo -u $userName defaults write $plistFilePath enableRendererLogs -bool false
+sudo -u $userName defaults write $plistFilePath ctWhitelist -array
+sudo -u $userName defaults write $plistFilePath podWhitelist -array
+sudo -u $userName defaults write $plistFilePath position -string "upper-right"
+sudo -u $userName defaults write $plistFilePath display -string ""
+sudo -u $userName defaults write $plistFilePath authServerWhitelist -string ""
+sudo -u $userName defaults write $plistFilePath authNegotiateDelegateWhitelist -string ""
+sudo -u $userName defaults write $plistFilePath disableThrottling -string "DISABLED"
+sudo -u $userName defaults write $plistFilePath media -bool true
+sudo -u $userName defaults write $plistFilePath geolocation -bool true
+sudo -u $userName defaults write $plistFilePath notifications -bool true
+sudo -u $userName defaults write $plistFilePath midiSysex -bool true
+sudo -u $userName defaults write $plistFilePath pointerLock -bool true
+sudo -u $userName defaults write $plistFilePath fullscreen -bool true
+sudo -u $userName defaults write $plistFilePath openExternal -bool true
+sudo -u $userName defaults write $plistFilePath autoLaunchPath -string ""
+sudo -u $userName defaults write $plistFilePath userDataPath -string ""
+sudo -u $userName defaults write $plistFilePath chromeFlags -string ""
+sudo -u $userName defaults write $plistFilePath betaAutoUpdateChannelEnabled -bool true
 
 ## Get Symphony Settings from the temp file ##
 pod_url=$(sed -n '1p' ${settingsFilePath});
@@ -35,25 +87,25 @@ pod_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$pod_url")
 context_origin_url_escaped=$(sed 's#[&/\]#\\&#g' <<<"$context_origin_url")
 
 ## Replace the default settings with the user selected settings ##
-sed -i "" -E "s#\"url\" ?: ?\".*\"#\"url\"\: \"$pod_url_escaped\"#g" "${newPath}"
-sed -i "" -E "s#\"contextOriginUrl\" ?: ?\".*\"#\"contextOriginUrl\"\: \"$context_origin_url_escaped\"#g" "${newPath}"
-sed -i "" -E "s#\"minimizeOnClose\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"minimizeOnClose\":\ \"$minimize_on_close\"#g" "${newPath}"
-sed -i "" -E "s#\"alwaysOnTop\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"alwaysOnTop\":\ \"$always_on_top\"#g" "${newPath}"
-sed -i "" -E "s#\"launchOnStartup\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"launchOnStartup\":\ \"$launch_on_startup\"#g" "${newPath}"
-sed -i "" -E "s#\"bringToFront\" ?: ?\"([Ee][Nn][Aa][Bb][Ll][Ee][Dd]|[Dd][Ii][Ss][Aa][Bb][Ll][Ee][Dd])\"#\"bringToFront\":\ \"$bring_to_front\"#g" "${newPath}"
-sed -i "" -E "s#\"devToolsEnabled\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"devToolsEnabled\":\ $dev_tools_enabled#g" "${newPath}"
-sed -i "" -E "s#\"enableBrowserLogin\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"enableBrowserLogin\":\ $enable_browser_login#g" "${newPath}"
-sed -i "" -E "s#\"browserLoginAutoConnect\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"browserLoginAutoConnect\":\ $browser_login_autoconnect#g" "${newPath}"
+plutil -replace url -string "${pod_url_escaped}" $plistFilePath
+plutil -replace contextOriginUrl -string "${context_origin_url_escaped}" $plistFilePath
+plutil -replace minimizeOnClose -string "${minimize_on_close}" $plistFilePath
+plutil -replace alwaysOnTop -string "${always_on_top}" $plistFilePath
+plutil -replace launchOnStartup -string "${launch_on_startup}" $plistFilePath
+plutil -replace bringToFront -string "${bring_to_front}" $plistFilePath
+plutil -replace devToolsEnabled -bool "${dev_tools_enabled}" $plistFilePath
+plutil -replace enableBrowserLogin -bool "${enable_browser_login}" $plistFilePath
+plutil -replace browserLoginAutoConnect -bool "${browser_login_autoconnect}" $plistFilePath
 
 ## Add settings force auto update
 force_auto_update=$(sed -n '10p' ${settingsFilePath});
 if [ "$force_auto_update" = "" ]; then force_auto_update=false; fi
-sed -i "" -E "s#\"forceAutoUpdate\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"forceAutoUpdate\":\ $force_auto_update#g" "${newPath}"
+plutil -replace forceAutoUpdate -bool "${force_auto_update}" $plistFilePath
 
 ## Add settings is pod url editable
 is_pod_url_editable=$(sed -n '11p' ${settingsFilePath});
 if [ "$is_pod_url_editable" = "" ]; then is_pod_url_editable=true; fi
-sed -i "" -E "s#\"isPodUrlEditable\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"isPodUrlEditable\":\ $is_pod_url_editable#g" "${newPath}"
+plutil -replace isPodUrlEditable -bool "${is_pod_url_editable}" $plistFilePath
 
 ## Get Symphony Permissions from the temp file ##
 media=$(sed -n '1p' ${permissionsFilePath});
@@ -74,16 +126,16 @@ if [ "$full_screen" = "" ]; then full_screen=true; fi
 if [ "$open_external_app" = "" ]; then open_external_app=true; fi
 
 ## Replace the default permissions with the user selected permissions ##
-sed -i "" -E "s#\"media\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"media\":\ $media#g" "${newPath}"
-sed -i "" -E "s#\"geolocation\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"geolocation\":\ $geo_location#g" "${newPath}"
-sed -i "" -E "s#\"notifications\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"notifications\":\ $notifications#g" "${newPath}"
-sed -i "" -E "s#\"midiSysex\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"midiSysex\":\ $midi_sysex#g" "${newPath}"
-sed -i "" -E "s#\"pointerLock\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"pointerLock\":\ $pointer_lock#g" "${newPath}"
-sed -i "" -E "s#\"fullscreen\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"fullscreen\":\ $full_screen#g" "${newPath}"
-sed -i "" -E "s#\"openExternal\" ?: ?([Tt][Rr][Uu][Ee]|[Ff][Aa][Ll][Ss][Ee])#\"openExternal\":\ $open_external_app#g" "${newPath}"
+plutil -replace media -bool "${media}" $plistFilePath
+plutil -replace geolocation -bool "${geo_location}" $plistFilePath
+plutil -replace notifications -bool "${notifications}" $plistFilePath
+plutil -replace midiSysex -bool "${midi_sysex}" $plistFilePath
+plutil -replace pointerLock -bool "${pointer_lock}" $plistFilePath
+plutil -replace fullscreen -bool "${full_screen}" $plistFilePath
+plutil -replace openExternal -bool "${open_external_app}" $plistFilePath
 
 ## Remove the temp settings & permissions file created ##
 rm -f ${settingsFilePath}
 rm -f ${permissionsFilePath}
 
-uuidgen > "${installVariantPath}"
+plutil -replace installVariant -string "${uuidgen}" $plistFilePath

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "symphony",
-  "version": "24.3.0",
+  "version": "24.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symphony",
-      "version": "24.3.0",
+      "version": "24.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/lazy-brush": "^1.0.0",
-        "archiver": "5.3.1",
+        "adm-zip": "^0.5.10",
         "async.map": "0.5.2",
         "classnames": "2.2.6",
         "electron-dl": "3.5.0",
@@ -3170,6 +3170,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "dev": true,
@@ -3554,54 +3562,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/archiver": {
-      "version": "5.3.1",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
@@ -3955,6 +3915,7 @@
     },
     "node_modules/async": {
       "version": "3.2.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/async-done": {
@@ -4341,6 +4302,7 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4387,6 +4349,7 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -4430,6 +4393,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4712,6 +4676,7 @@
     },
     "node_modules/buffer": {
       "version": "5.7.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4748,6 +4713,7 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -5483,32 +5449,9 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/compress-commons": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/compress-commons/node_modules/crc32-stream": {
-      "version": "4.0.2",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-stream": {
@@ -5629,6 +5572,7 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -5670,16 +5614,6 @@
       "optional": true,
       "dependencies": {
         "buffer": "^5.1.0"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/create-ecdh": {
@@ -7098,6 +7032,7 @@
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -8185,10 +8120,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "dev": true,
@@ -8387,6 +8318,7 @@
     },
     "node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -9752,6 +9684,7 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9881,6 +9814,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -9889,6 +9823,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -10421,6 +10356,7 @@
     },
     "node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isbinaryfile": {
@@ -11928,6 +11864,7 @@
     },
     "node_modules/lazystream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readable-stream": "^2.0.5"
@@ -11938,6 +11875,7 @@
     },
     "node_modules/lazystream/node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -12159,14 +12097,6 @@
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "license": "MIT"
-    },
-    "node_modules/lodash.difference": {
-      "version": "4.5.0",
-      "license": "MIT"
-    },
     "node_modules/lodash.escape": {
       "version": "4.0.1",
       "dev": true,
@@ -12174,10 +12104,6 @@
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
-      "license": "MIT"
-    },
-    "node_modules/lodash.flatten": {
-      "version": "4.4.0",
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
@@ -12194,10 +12120,6 @@
       "version": "4.5.0",
       "license": "MIT"
     },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "3.0.4",
       "dev": true,
@@ -12206,10 +12128,6 @@
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.union": {
-      "version": "4.6.0",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -12685,6 +12603,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -13246,6 +13165,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13593,6 +13513,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -13949,6 +13870,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14484,6 +14406,7 @@
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
@@ -14900,6 +14823,7 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -14908,30 +14832,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/realpath-native": {
@@ -15435,6 +15335,7 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex": {
@@ -16448,6 +16349,7 @@
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -16906,20 +16808,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/fs-minipass": {
@@ -17786,6 +17674,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -18183,6 +18072,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -18362,18 +18252,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     }
   },
@@ -20581,6 +20459,11 @@
       "version": "7.2.0",
       "dev": true
     },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
+    },
     "agent-base": {
       "version": "6.0.2",
       "dev": true,
@@ -20837,47 +20720,6 @@
       "version": "2.0.0",
       "dev": true
     },
-    "archiver": {
-      "version": "5.3.1",
-      "requires": {
-        "archiver-utils": "^2.1.0",
-        "async": "^3.2.3",
-        "buffer-crc32": "^0.2.1",
-        "readable-stream": "^3.6.0",
-        "readdir-glob": "^1.0.0",
-        "tar-stream": "^2.2.0",
-        "zip-stream": "^4.1.0"
-      }
-    },
-    "archiver-utils": {
-      "version": "2.1.0",
-      "requires": {
-        "glob": "^7.1.4",
-        "graceful-fs": "^4.2.0",
-        "lazystream": "^1.0.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.union": "^4.6.0",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        }
-      }
-    },
     "archy": {
       "version": "1.0.0",
       "dev": true
@@ -21112,7 +20954,8 @@
       "optional": true
     },
     "async": {
-      "version": "3.2.3"
+      "version": "3.2.3",
+      "dev": true
     },
     "async-done": {
       "version": "1.3.2",
@@ -21385,7 +21228,8 @@
       }
     },
     "base64-js": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -21408,6 +21252,7 @@
     },
     "bl": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -21444,6 +21289,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -21671,6 +21517,7 @@
     },
     "buffer": {
       "version": "5.7.1",
+      "dev": true,
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -21689,7 +21536,8 @@
       "dev": true
     },
     "buffer-crc32": {
-      "version": "0.2.13"
+      "version": "0.2.13",
+      "dev": true
     },
     "buffer-equal": {
       "version": "0.0.1",
@@ -22186,26 +22034,9 @@
       "version": "1.3.0",
       "dev": true
     },
-    "compress-commons": {
-      "version": "4.1.1",
-      "requires": {
-        "buffer-crc32": "^0.2.13",
-        "crc32-stream": "^4.0.2",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "crc32-stream": {
-          "version": "4.0.2",
-          "requires": {
-            "crc-32": "^1.2.0",
-            "readable-stream": "^3.4.0"
-          }
-        }
-      }
-    },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -22299,7 +22130,8 @@
       }
     },
     "core-util-is": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "7.0.0",
@@ -22331,9 +22163,6 @@
       "requires": {
         "buffer": "^5.1.0"
       }
-    },
-    "crc-32": {
-      "version": "1.2.2"
     },
     "create-ecdh": {
       "version": "4.0.4",
@@ -23309,6 +23138,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -24077,9 +23907,6 @@
         "map-cache": "^0.2.2"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0"
-    },
     "fs-extra": {
       "version": "8.1.0",
       "dev": true,
@@ -24206,6 +24033,7 @@
     },
     "glob": {
       "version": "7.1.6",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -25165,7 +24993,8 @@
       }
     },
     "ieee754": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "dev": true
     },
     "ignore": {
       "version": "5.1.8",
@@ -25236,13 +25065,15 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -25555,7 +25386,8 @@
       }
     },
     "isarray": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "5.0.0",
@@ -26621,12 +26453,14 @@
     },
     "lazystream": {
       "version": "1.0.0",
+      "dev": true,
       "requires": {
         "readable-stream": "^2.0.5"
       },
       "dependencies": {
         "readable-stream": {
           "version": "2.3.7",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -26781,21 +26615,12 @@
       "resolved": "https://repo.symphony.com/artifactory/api/npm/npm-virtual-dev/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "lodash.defaults": {
-      "version": "4.2.0"
-    },
-    "lodash.difference": {
-      "version": "4.5.0"
-    },
     "lodash.escape": {
       "version": "4.0.1",
       "dev": true
     },
     "lodash.escaperegexp": {
       "version": "4.1.2"
-    },
-    "lodash.flatten": {
-      "version": "4.4.0"
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -26808,9 +26633,6 @@
     "lodash.isequal": {
       "version": "4.5.0"
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6"
-    },
     "lodash.memoize": {
       "version": "3.0.4",
       "dev": true
@@ -26818,9 +26640,6 @@
     "lodash.sortby": {
       "version": "4.7.0",
       "dev": true
-    },
-    "lodash.union": {
-      "version": "4.6.0"
     },
     "log-symbols": {
       "version": "4.1.0",
@@ -27160,6 +26979,7 @@
     },
     "minimatch": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -27553,7 +27373,8 @@
       }
     },
     "normalize-path": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "normalize-url": {
       "version": "6.1.0",
@@ -27771,6 +27592,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -28010,7 +27832,8 @@
       "version": "4.0.0"
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -28345,7 +28168,8 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.1"
+      "version": "2.0.1",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -28654,30 +28478,11 @@
     },
     "readable-stream": {
       "version": "3.6.0",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
-      }
-    },
-    "readdir-glob": {
-      "version": "1.1.2",
-      "requires": {
-        "minimatch": "^5.1.0"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.6",
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
       }
     },
     "realpath-native": {
@@ -29033,7 +28838,8 @@
       "devOptional": true
     },
     "safe-buffer": {
-      "version": "5.1.2"
+      "version": "5.1.2",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -29741,6 +29547,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -30076,16 +29883,6 @@
           "version": "1.0.4",
           "dev": true
         }
-      }
-    },
-    "tar-stream": {
-      "version": "2.2.0",
-      "requires": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
       }
     },
     "temp-file": {
@@ -30666,7 +30463,8 @@
       }
     },
     "util-deprecate": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "uuid": {
       "version": "3.4.0",
@@ -30965,7 +30763,8 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -31086,14 +30885,6 @@
     "yocto-queue": {
       "version": "0.1.0",
       "dev": true
-    },
-    "zip-stream": {
-      "version": "4.1.0",
-      "requires": {
-        "archiver-utils": "^2.1.0",
-        "compress-commons": "^4.1.0",
-        "readable-stream": "^3.6.0"
-      }
     }
   }
 }

--- a/spec/__mocks__/electron.ts
+++ b/spec/__mocks__/electron.ts
@@ -290,6 +290,10 @@ export const screen = {
   }),
 };
 
+export const systemPreferences = {
+  getUserDefault: jest.fn(),
+};
+
 export const remote = {
   app,
   getCurrentWindow,

--- a/spec/childWindowHandle.spec.ts
+++ b/spec/childWindowHandle.spec.ts
@@ -60,6 +60,10 @@ jest.mock('../src/app/auto-update-handler', () => {
   return {};
 });
 
+jest.mock('../src/app/config-handler', () => {
+  return {};
+});
+
 describe('child window handle', () => {
   it('should set open window handler', () => {
     const spy = jest.spyOn(webContents, 'setWindowOpenHandler');

--- a/spec/dialogHandler.spec.ts
+++ b/spec/dialogHandler.spec.ts
@@ -39,6 +39,47 @@ jest.mock('../src/app/window-handler', () => {
   };
 });
 
+jest.mock('../src/app/plist-handler', () => {
+  return {};
+});
+jest.mock('../src/app/config-handler', () => {
+  return {
+    CloudConfigDataTypes: {
+      NOT_SET: 'NOT_SET',
+      ENABLED: 'ENABLED',
+      DISABLED: 'DISABLED',
+    },
+    config: {
+      getConfigFields: jest.fn(() => {
+        return {
+          minimizeOnClose: 'ENABLED',
+          launchOnStartup: 'ENABLED',
+          alwaysOnTop: 'ENABLED',
+          isAlwaysOnTop: 'ENABLED',
+          bringToFront: 'ENABLED',
+          devToolsEnabled: true,
+        };
+      }),
+      getGlobalConfigFields: jest.fn(() => {
+        return {
+          devToolsEnabled: true,
+        };
+      }),
+      getFilteredCloudConfigFields: jest.fn(() => {
+        return {
+          devToolsEnabled: true,
+        };
+      }),
+      getCloudConfigFields: jest.fn(() => {
+        return {
+          devToolsEnabled: true,
+        };
+      }),
+      updateUserConfig: jest.fn(),
+    },
+  };
+});
+
 jest.mock('../src/renderer/notification', () => {
   return {
     setupNotificationPosition: jest.fn(),

--- a/spec/plistHandler.spec.ts
+++ b/spec/plistHandler.spec.ts
@@ -1,0 +1,54 @@
+import { getAllUserDefaults } from '../src/app/plist-handler';
+
+describe('Plist Handler', () => {
+  it('should return config object', () => {
+    expect(getAllUserDefaults()).toStrictEqual({
+      alwaysOnTop: undefined,
+      autoLaunchPath: undefined,
+      autoUpdateChannel: undefined,
+      autoUpdateCheckInterval: undefined,
+      autoUpdateUrl: undefined,
+      betaAutoUpdateChannelEnabled: undefined,
+      bringToFront: undefined,
+      browserLoginAutoConnect: undefined,
+      chromeFlags: {
+        authNegotiateDelegateWhitelist: undefined,
+        authServerWhitelist: undefined,
+        disableThrottling: undefined,
+      },
+      contextIsolation: undefined,
+      contextOriginUrl: undefined,
+      ctWhitelist: undefined,
+      devToolsEnabled: undefined,
+      disableGpu: undefined,
+      enableBrowserLogin: undefined,
+      enableRendererLogs: undefined,
+      forceAutoUpdate: undefined,
+      isAutoUpdateEnabled: undefined,
+      isCustomTitleBar: undefined,
+      isPodUrlEditable: undefined,
+      launchOnStartup: undefined,
+      memoryRefresh: undefined,
+      memoryThreshold: undefined,
+      minimizeOnClose: undefined,
+      notificationSettings: {
+        display: undefined,
+        position: undefined,
+      },
+      overrideUserAgent: undefined,
+      permissions: {
+        fullscreen: undefined,
+        geolocation: undefined,
+        media: undefined,
+        midiSysex: undefined,
+        notifications: undefined,
+        openExternal: undefined,
+        pointerLock: undefined,
+      },
+      podWhitelist: undefined,
+      url: undefined,
+      userDataPath: undefined,
+      whitelistUrl: undefined,
+    });
+  });
+});

--- a/src/app/config-handler.ts
+++ b/src/app/config-handler.ts
@@ -1,4 +1,4 @@
-import { app, dialog, powerSaveBlocker } from 'electron';
+import { app, dialog, powerSaveBlocker, systemPreferences } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -16,6 +16,7 @@ import {
   SDAUserSessionActionTypes,
 } from './bi/interface';
 import { terminateC9Shell } from './c9-shell-handler';
+import { getAllUserDefaults } from './plist-handler';
 import { appStats } from './stats';
 
 const writeFile = util.promisify(fs.writeFile);
@@ -786,12 +787,20 @@ class Config {
    * Reads a stores the global config file
    */
   private readGlobalConfig() {
+    if (isMac) {
+      this.globalConfig = getAllUserDefaults();
+      logger.info(
+        `config-handler: Global configuration from plist: `,
+        this.globalConfig,
+      );
+      return;
+    }
     if (!fs.existsSync(this.globalConfigPath)) {
       throw new Error(
         `Global config file missing! App will not run as expected!`,
       );
     }
-    if (fs.existsSync(this.tempGlobalConfigFilePath)) {
+    /*if (fs.existsSync(this.tempGlobalConfigFilePath)) {
       this.globalConfig = this.parseConfigData(
         fs.readFileSync(this.tempGlobalConfigFilePath, 'utf8'),
       );
@@ -804,7 +813,7 @@ class Config {
         this.copyGlobalConfig();
       }
       return;
-    }
+    }*/
     const parsedConfigData = this.parseConfigData(
       fs.readFileSync(this.globalConfigPath, 'utf8'),
     );
@@ -818,6 +827,17 @@ class Config {
    * Reads the install variant from a file
    */
   private readInstallVariant() {
+    if (isMac) {
+      this.installVariant = systemPreferences.getUserDefault(
+        'installVariant',
+        'string',
+      );
+      logger.info(
+        `config-handler: Install variant from plist: `,
+        this.installVariant,
+      );
+      return;
+    }
     this.installVariant = fs.readFileSync(this.installVariantPath, 'utf8');
     logger.info(`config-handler: Install variant: `, this.installVariant);
   }

--- a/src/app/plist-handler.ts
+++ b/src/app/plist-handler.ts
@@ -1,0 +1,96 @@
+import { systemPreferences } from 'electron';
+import { logger } from '../common/logger';
+import { IConfig } from './config-handler';
+
+const GENERAL_SETTINGS = {
+  url: 'string',
+  autoUpdateUrl: 'string',
+  autoUpdateChannel: 'string',
+  isAutoUpdateEnabled: 'boolean',
+  isPodUrlEditable: 'boolean',
+  forceAutoUpdate: 'boolean',
+  autoUpdateCheckInterval: 'string',
+  enableBrowserLogin: 'boolean',
+  browserLoginAutoConnect: 'boolean',
+  overrideUserAgent: 'boolean',
+  minimizeOnClose: 'string',
+  launchOnStartup: 'string',
+  alwaysOnTop: 'string',
+  bringToFront: 'string',
+  whitelistUrl: 'string',
+  isCustomTitleBar: 'string',
+  memoryRefresh: 'string',
+  memoryThreshold: 'string',
+  devToolsEnabled: 'boolean',
+  contextIsolation: 'boolean',
+  contextOriginUrl: 'string',
+  disableGpu: 'boolean',
+  enableRendererLogs: 'boolean',
+  ctWhitelist: 'array',
+  podWhitelist: 'array',
+  autoLaunchPath: 'string',
+  userDataPath: 'string',
+  chromeFlags: 'string',
+  betaAutoUpdateChannelEnabled: 'boolean',
+};
+
+const NOTIFICATION_SETTINGS = {
+  position: 'string',
+  display: 'string',
+};
+
+const CHROME_FLAGS = {
+  authServerWhitelist: 'string',
+  authNegotiateDelegateWhitelist: 'string',
+  disableThrottling: 'string',
+};
+
+const PERMISSIONS = {
+  media: 'boolean',
+  geolocation: 'boolean',
+  notifications: 'boolean',
+  midiSysex: 'boolean',
+  pointerLock: 'boolean',
+  fullscreen: 'boolean',
+  openExternal: 'boolean',
+};
+
+export const getAllUserDefaults = (): IConfig => {
+  const settings: any = {};
+
+  Object.keys(GENERAL_SETTINGS).map((key) => {
+    settings[key] = systemPreferences.getUserDefault(
+      key,
+      GENERAL_SETTINGS[key],
+    );
+  });
+  Object.keys(NOTIFICATION_SETTINGS).map((key) => {
+    if (!settings.notificationSettings) {
+      settings.notificationSettings = {};
+    }
+    settings.notificationSettings[key] = systemPreferences.getUserDefault(
+      key,
+      NOTIFICATION_SETTINGS[key],
+    );
+  });
+  Object.keys(CHROME_FLAGS).map((key) => {
+    if (!settings.chromeFlags) {
+      settings.chromeFlags = {};
+    }
+    settings.chromeFlags[key] = systemPreferences.getUserDefault(
+      key,
+      CHROME_FLAGS[key],
+    );
+  });
+  Object.keys(PERMISSIONS).map((key) => {
+    if (!settings.permissions) {
+      settings.permissions = {};
+    }
+    settings.permissions[key] = systemPreferences.getUserDefault(
+      key,
+      PERMISSIONS[key],
+    );
+  });
+  logger.info('plist-handler: getting all user defaults', settings);
+  return settings;
+};


### PR DESCRIPTION
## Description
- Migrate Symphony.config & installVariant into `/Library/Preference`

Leverages `systemPreferences.getUserDefault` to retrieve data from .plist files, configuring the application globally instead of relying on the `/config/Symphony.config` file.