### PR TITLE
SDA-4481: Add Fix to image cannot be copied

### DIFF
--- a/src/app/context-menu-builder.ts
+++ b/src/app/context-menu-builder.ts
@@ -1,6 +1,8 @@
 import { BrowserWindow, clipboard, Menu, MenuItem, shell } from 'electron';
+import { apiName } from '../common/api-interface';
 import { isDevEnv } from '../common/env';
 import { logger } from '../common/logger';
+import { ICustomBrowserWindow } from './window-handler';
 
 interface IContextMenuStringTable {
   copyMail: () => string;
@@ -376,12 +378,19 @@ export class ContextMenuBuilder {
    * Adds "Copy Image" and "Copy Image URL" items when `src` is valid.
    */
   public addImageItems(menu, menuInfo) {
-    const target = this.getWebContents();
+    const current = this.getWebContents();
+    const focusedWindow =
+      BrowserWindow.getFocusedWindow() as ICustomBrowserWindow;
     const copyImage = new MenuItem({
       label: this.stringTable.copyImage(),
       click: (_e) => {
+        if (focusedWindow && focusedWindow.winName === apiName.mainWindowName) {
+          current?.send('copy-to-clipboard', menuInfo.srcURL);
+        } else {
+          current.copyImageAt(menuInfo.x, menuInfo.y);
+        }
+
         logger.info('Context-Menu-Builder: Copy Image to clipboard');
-        target.send('copy-to-clipboard', menuInfo.srcURL);
       },
     });
 


### PR DESCRIPTION
## Description
The fix targets to remove regression on cannot copy image of Workspace / Popout. This fix does not include pasting from workspace/popout to 3rd parties, currently tech limitation.



## Related PRs

## Demo
https://github.com/finos/SymphonyElectron/assets/97150869/8b80d832-f336-4b3b-916d-b94675cfc114

