### PR TITLE
SDA-4528: Minimize Windows wont disappear on capture with SDA Hidden

### DIFF
--- a/src/app/stores/window-store.ts
+++ b/src/app/stores/window-store.ts
@@ -95,16 +95,19 @@ export class WindowStore {
       const fullscreenedWindows: IWindowState[] = [];
       // Restoring all windows except focused one
       storedWindows.windows.forEach((currentWindow) => {
-        if (currentWindow && currentWindow.isVisible) {
+        if (currentWindow) {
           const window: ICustomBrowserWindow | undefined = getWindowByName(
             currentWindow.id || '',
           ) as ICustomBrowserWindow;
           if (window) {
             if (currentWindow.isFullScreen) {
               fullscreenedWindows.push(currentWindow);
-            } else if (!currentWindow.minimized && !currentWindow.focused) {
+            } else if (!currentWindow.focused) {
               window.showInactive();
               window.moveTop();
+              if (currentWindow.minimized) {
+                window.minimize();
+              }
             }
             if (currentWindow.focused) {
               focusedWindowToRestore = window;


### PR DESCRIPTION
## Description
Fixing a bug relating to capture screenshot with application hidden,
If you minimize a popout and capture with app hidden, then the minimized popout will be temporarily disappeared until the next reload

## Related PRs
