### PR TITLE
SDA-4544 Allow to load React dev tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symphony",
-  "version": "24.4.0",
+  "version": "24.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symphony",
-      "version": "24.4.0",
+      "version": "24.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/src/app/extension-handler.ts
+++ b/src/app/extension-handler.ts
@@ -1,0 +1,101 @@
+import { session } from 'electron';
+import { promises } from 'fs';
+import * as os from 'os';
+import path = require('path');
+
+import { Logger } from '../common/loggerBase';
+import { getCommandLineArgs } from '../common/utils';
+
+/**
+ * Return Chrome extensions folder path if it exists
+ * @returns Promise<string> Chrome extensions folder path if it exists or empty string
+ */
+const getExtensionsFolderPath = async (extensionId: string) => {
+  const platform = os.platform();
+  if (platform === 'win32') {
+    const { LOCALAPPDATA } = process.env;
+    const dataPath = `${LOCALAPPDATA}\\Google\\Chrome\\User Data\\`;
+    let userPath = `${dataPath}Default`;
+    let extensionPath = `${userPath}\\Extensions\\${extensionId}`;
+
+    extensionPath = await exists(extensionPath);
+    if (extensionPath) {
+      return extensionPath;
+    }
+
+    let userId = 0;
+    userPath = `${dataPath}Profile ${userId}`;
+    do {
+      extensionPath = await exists(`${userPath}\\Extensions\\${extensionId}`);
+      userPath = `${dataPath}Profile ${++userId}`;
+    } while (!extensionPath && (await exists(userPath)));
+
+    return extensionPath;
+  } else if (platform === 'darwin') {
+    const macOsPath = `/Library/Application Support/Google/Chrome/Default/Extensions/${extensionId}`;
+    return exists(macOsPath);
+  } else if (platform === 'linux') {
+    const paths = [
+      `~/.config/google-chrome/Default/Extensions/${extensionId}`,
+      `~/.config/google-chrome-beta/Default/Extensions/${extensionId}`,
+      `~/.config/google-chrome-canary/Default/Extensions/${extensionId}`,
+      `~/.config/chromium/Default/Extensions/${extensionId}`,
+    ];
+
+    for (const path of paths) {
+      if (await exists(path)) {
+        return path;
+      }
+    }
+  }
+  return '';
+};
+
+/**
+ * Load React Dev Tools extension
+ * @param logger
+ * @returns Promise<void>
+ */
+export const loadReactDevToolsExtension = async (logger: Logger) => {
+  if (
+    !getCommandLineArgs(process.argv, '--reactDevToolsEnabled', true) &&
+    !getCommandLineArgs(process.argv, '--reactDevToolsEnabled=1', true) &&
+    !getCommandLineArgs(process.argv, '--reactDevToolsEnabled=true', true)
+  ) {
+    return;
+  }
+
+  const reactDevToolsExtensionId = 'fmkadmapgofadopljbjfkapdkoienihi';
+  let extensionsPath = await getExtensionsFolderPath(reactDevToolsExtensionId);
+  if (!extensionsPath) {
+    logger.info(`main: ReactDevTools extension not found`);
+    return;
+  }
+
+  const versionFolders = await readdir(extensionsPath);
+  if (!versionFolders.length) {
+    logger.info(`main: ReactDevTools extension version folder not found`);
+    return;
+  }
+  extensionsPath = path.join(extensionsPath, versionFolders[0]);
+
+  logger.info(`main: Loading ReactDevTools extension ${versionFolders[0]}`);
+  await session.defaultSession.loadExtension(extensionsPath);
+  logger.info(`main: ReactDevTools extension loaded`);
+};
+
+const { access, constants, readdir } = promises;
+
+/**
+ * Asynchronously check if path exists
+ * @param path
+ * @returns Promise<string> path if path exists or empty string
+ */
+const exists = async (path: string) => {
+  try {
+    await access(path, constants.R_OK);
+    return path;
+  } catch (error) {
+    return '';
+  }
+};

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1,4 +1,4 @@
-import { app, systemPreferences } from 'electron';
+import { app, session, systemPreferences } from 'electron';
 import * as electronDownloader from 'electron-dl';
 
 import { isDevEnv, isLinux, isMac } from '../common/env';
@@ -13,9 +13,14 @@ import { handlePerformanceSettings } from './perf-handler';
 import { protocolHandler } from './protocol-handler';
 import { ICustomBrowserWindow, windowHandler } from './window-handler';
 
+import { promises } from 'fs';
+import * as os from 'os';
+import path = require('path');
+import { Logger } from '../common/loggerBase';
 import { autoLaunchInstance } from './auto-launch-controller';
 import { presenceStatusStore } from './stores';
 
+const { access, constants, readdir } = promises;
 // Set automatic period substitution to false because of a bug in draft js on the client app
 // See https://perzoinc.atlassian.net/browse/SDA-2215 for more details
 if (isMac) {
@@ -75,6 +80,85 @@ if (!isDevEnv) {
 }
 
 /**
+ * Asynchronously check if path exists
+ * @param path
+ * @returns Promise<string> path if path exists or empty string
+ */
+const exists = async (path: string) => {
+  try {
+    await access(path, constants.R_OK);
+    return path;
+  } catch (error) {
+    return '';
+  }
+};
+
+/**
+ * Return Chrome extensions folder path if it exists
+ * @returns Promise<string> Chrome extensions folder path if it exists or empty string
+ */
+const getExtensionsFolderPath = async () => {
+  switch (os.platform()) {
+    case 'win32':
+      const winPath =
+        process.env.LOCALAPPDATA +
+        '\\Google\\Chrome\\User Data\\Default\\Extensions';
+      return exists(winPath);
+    case 'darwin':
+      const macOsPath =
+        '/Library/Application Support/Google/Chrome/Default/Extensions';
+      return exists(macOsPath);
+    case 'linux':
+      const paths = [
+        '~/.config/google-chrome/Default/Extensions/',
+        '~/.config/google-chrome-beta/Default/Extensions/',
+        '~/.config/google-chrome-canary/Default/Extensions/',
+        '~/.config/chromium/Default/Extensions/',
+      ];
+      for (const path of paths) {
+        if (await exists(path)) {
+          return path;
+        }
+      }
+  }
+  return '';
+};
+
+/**
+ * Load React Dev Tools extension
+ * @param logger
+ * @returns Promise<void>
+ */
+const loadReactDevToolsExtension = async (logger: Logger) => {
+  if (
+    !getCommandLineArgs(process.argv, '--reactDevToolsEnabled', true) &&
+    !getCommandLineArgs(process.argv, '--reactDevToolsEnabled=1', true) &&
+    !getCommandLineArgs(process.argv, '--reactDevToolsEnabled=true', true)
+  ) {
+    return;
+  }
+
+  const extensionsPath = await getExtensionsFolderPath();
+
+  let reactDevToolsPath =
+    extensionsPath &&
+    path.join(extensionsPath, 'fmkadmapgofadopljbjfkapdkoienihi');
+  if (!reactDevToolsPath) {
+    return;
+  }
+
+  const versionFolders = await readdir(reactDevToolsPath);
+  if (!versionFolders.length) {
+    return;
+  }
+
+  logger.info(`main: Loading ReactDevTools extension ${versionFolders[0]}`);
+  reactDevToolsPath = path.join(reactDevToolsPath, versionFolders[0]);
+  await session.defaultSession.loadExtension(reactDevToolsPath);
+  logger.info(`main: ReactDevTools extension loaded`);
+};
+
+/**
  * Main function that initialises the application
  */
 let oneStart = false;
@@ -109,6 +193,7 @@ const startApplication = async () => {
   setSessionProperties();
   await windowHandler.createApplication();
   logger.info(`main: created application`);
+  await loadReactDevToolsExtension(logger);
 };
 
 // Handle multiple/single instances


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/SDA-4544

```markdown
# Run Startpage in WSL
cd ~/work/symphony/startpage/startpage-service
mvn spring-boot:run -Dspring-boot.run.profiles=local
# Run SFE with Startpage targeting ST3 in WSL
cd ~/work/symphony/sfe-lite
yarn watch --pod st3.dev --useStartpage client2
# Run C9 in WSL
~/work/symphony/sfe-rtc/packages/symphony-c9
yarn watch
# Run SDA
## In Powershell: 3 dashes
npm run dev --- --reactDevToolsEnabled --url=https://local-dev.symphony.com:9090/apps/client2?sp-extension=symphony-c9:local --c9args="-a -r https://rest-jjj.qa2.xhoot.com/" --userDataPath="C:\\sym-configs\\u1"
## In cmd: 2 dashes
npm run dev -- --reactDevToolsEnabled --url=https://local-dev.symphony.com:9090/apps/client2?sp-extension=symphony-c9:local --c9args="-a -r https://rest-jjj.qa2.xhoot.com" --userDataPath="C:\\sym-configs\\u1"
```
<img width="860" alt="image" src="https://github.com/finos/SymphonyElectron/assets/112877883/458cfb06-6efd-46f4-b1e5-49922178a181">