### PR TITLE
Upgrade electron@29.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "builder-util-runtime": "^9.0.3",
     "cross-env": "7.0.3",
     "del": "3.0.0",
-    "electron": "29.1.5",
+    "electron": "29.3.0",
     "electron-builder": "^24.13.2",
     "electron-icon-maker": "0.0.5",
     "electron-osx-sign": "^0.6.0",


### PR DESCRIPTION
## Description

Upgrade electron@29.3.0

Fixes:
[CVE-2024-2625](https://github.com/advisories/GHSA-j7h3-fcrw-g6j8)
[CVE-2024-2885](https://github.com/advisories/GHSA-qccw-wmvp-8pv9)
[CVE-2024-3159](https://github.com/advisories/GHSA-mh2p-2x66-3hr4)