### PR TITLE
SDA-4604 Limiting window activation change to macOS for bring-to-front feature only

### DIFF
--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -340,7 +340,7 @@ describe('main api handler', () => {
         reason: 'notification',
         windowName: 'notification',
       };
-      const expectedValue = ['notification'];
+      const expectedValue = ['notification', false];
       ipcMain.send(apiName.symphonyApi, value);
       expect(spy).toBeCalledWith(...expectedValue);
     });

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -207,7 +207,7 @@ ipcMain.on(
         if (typeof arg.reason === 'string' && arg.reason === 'notification') {
           const { bringToFront } = config.getConfigFields(['bringToFront']);
           if (bringToFront === CloudConfigDataTypes.ENABLED) {
-            activate(arg.windowName);
+            activate(arg.windowName, false);
           }
         }
         break;

--- a/src/app/window-actions.ts
+++ b/src/app/window-actions.ts
@@ -187,9 +187,7 @@ export const activate = (
         // Bring the window to the top without focusing
         // Flash task bar icon in Windows for windows
         if (!shouldFocus) {
-          return isMac || isLinux
-            ? window.showInactive()
-            : window.flashFrame(true);
+          return isMac || isLinux ? window.show() : window.flashFrame(true);
         }
 
         // Note: On window just focusing will preserve window snapped state


### PR DESCRIPTION
## Description

Backport #2176
