### PR TITLE
SDA-4792 - Bump native tool versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symphony",
-  "version": "25.2.0",
+  "version": "25.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "symphony",
-      "version": "25.2.0",
+      "version": "25.3.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -79,9 +79,9 @@
       },
       "optionalDependencies": {
         "@symphony/symphony-c9-shell": "3.38.0-94.195",
-        "screen-share-indicator-frame": "github:finos/ScreenShareIndicatorFrame#v1.5.0",
-        "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
-        "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
+        "screen-share-indicator-frame": "github:finos/ScreenShareIndicatorFrame#v1.6.0",
+        "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#v2.5.0",
+        "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#v1.1.0",
         "winreg": "^1.2.4"
       }
     },

--- a/package.json
+++ b/package.json
@@ -243,9 +243,9 @@
   },
   "optionalDependencies": {
     "@symphony/symphony-c9-shell": "3.38.0-94.195",
-    "screen-share-indicator-frame": "github:finos/ScreenShareIndicatorFrame#v1.5.0",
-    "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#9.2.2",
-    "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#1.0.1",
+    "screen-share-indicator-frame": "github:finos/ScreenShareIndicatorFrame#v1.6.0",
+    "screen-snippet": "git+https://github.com/finos/ScreenSnippet2.git#v2.5.0",
+    "symphony-native-window-handle-helper": "github:finos/SymphonyWindowsHwndHelper#v1.1.0",
     "winreg": "^1.2.4"
   },
   "ava": {


### PR DESCRIPTION
## Description
- Bump native tool versions
- Update the application icon for all the native tools
  - screen-share-indicator-frame
  - screen-snippet
  - symphony-native-window-handle-helper
