### PR TITLE
C2-25477: OpenFin - `setContext` in session context group

### DIFF
--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -20,6 +20,7 @@ jest.mock('../src/app/openfin-handler', () => {
     openfinHandler: {
       connect: jest.fn(),
       fireIntent: jest.fn(),
+      setContext: jest.fn(),
       joinContextGroup: jest.fn(),
       joinSessionContextGroup: jest.fn(),
       getContextGroups: jest.fn(),
@@ -748,6 +749,31 @@ describe('main api handler', () => {
       ipcMain.send(apiName.symphonyApi, value);
 
       expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call `setContext`', () => {
+      const spy = jest.spyOn(openfinHandler, 'setContext');
+      const value = {
+        cmd: apiCmds.openfinSetContext,
+        context: 'context',
+      };
+
+      ipcMain.send(apiName.symphonyApi, value);
+
+      expect(spy).toHaveBeenCalledWith('context', undefined);
+    });
+
+    it('should call `setContext` with session group id', () => {
+      const spy = jest.spyOn(openfinHandler, 'setContext');
+      const value = {
+        cmd: apiCmds.openfinSetContext,
+        context: 'context',
+        sessionContextGroupId: 'session-context-group-id',
+      };
+
+      ipcMain.send(apiName.symphonyApi, value);
+
+      expect(spy).toHaveBeenCalledWith('context', 'session-context-group-id');
     });
   });
 });

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -655,7 +655,10 @@ ipcMain.handle(
       case apiCmds.openfinRemoveFromContextGroup:
         return openfinHandler.removeFromContextGroup();
       case apiCmds.openfinSetContext:
-        return openfinHandler.setContext(arg.context);
+        return openfinHandler.setContext(
+          arg.context,
+          arg.sessionContextGroupId,
+        );
       default:
         break;
     }

--- a/src/renderer/ssf-api.ts
+++ b/src/renderer/ssf-api.ts
@@ -1131,10 +1131,11 @@ export class SSFApi {
    * Sets a context for the context group of the current entity.
    * @param context
    */
-  public async openfinSetContext(context: any) {
+  public async openfinSetContext(context: any, sessionContextGroupId?: string) {
     const response = await local.ipcRenderer.invoke(apiName.symphonyApi, {
       cmd: apiCmds.openfinSetContext,
       context,
+      sessionContextGroupId,
     });
     return response;
   }


### PR DESCRIPTION
**C2-25477: OpenFin - `setContext` in session context group**

In the OpenFin world, broadcasting a context in a session context group is different from broadcasting in a default context group.

The default context group way:
``` js
await openfin.joinContextGroup(id);
await openfin.setContext(context)
```

The session context group way:
``` js
const group = await openfin.joinSessionContextGroup(id);
await group.setContext(context)
```