### PR TITLE
SDA-4916_new: Implement a new way to add logs

### DIFF
--- a/spec/helpers/files-helper.spec.ts
+++ b/spec/helpers/files-helper.spec.ts
@@ -1,0 +1,115 @@
+import * as fs from 'fs';
+import {
+  convertFileName,
+  isValidWindowsFileName,
+  isValidWindowsFilePath,
+  copyOneSingleFile,
+  copyFiles,
+  copyFileUsingReadWrite,
+} from '../../src/app/helpers/file/files-helper';
+import { isWindowsOS } from '../../src/common/env';
+
+describe('files-helper', () => {
+  let fsMock;
+  let logs = [
+    'C9Zeus.2529612.log',
+    'C9Zeus.1.log',
+    'C9Trader.25296.log',
+    'C9Trader.25.log',
+    'HEHE.txt',
+    'HAH.txt',
+  ];
+  beforeEach(() => {
+    fsMock = jest.spyOn(fs, 'readdirSync').mockImplementation(() => logs);
+  });
+
+  afterEach(() => {
+    fsMock.mockRestore();
+  });
+
+  it('should clean file names', () => {
+    const validatedFileName = convertFileName('console.log("hello world").txt');
+
+    expect(validatedFileName).toBe('console.log__hello_world__.txt');
+  });
+
+  it('should have a proper file path - false', () => {
+    const validatedPath = isValidWindowsFilePath(
+      'SELEC*FROM ABC/hello-world/haha',
+    );
+
+    expect(validatedPath).toBe(false);
+  });
+
+  it('should clean file path - true', () => {
+    const validatedPath = isValidWindowsFilePath('C:\\Users');
+
+    if (isWindowsOS) {
+      expect(validatedPath).toBe(true);
+    } else {
+      expect(validatedPath).toBe(false);
+    }
+  });
+
+  it('should return true if file name did not violate any rules', () => {
+    const validatedPath = isValidWindowsFileName('abcdef.log');
+
+    expect(validatedPath).toBe(true);
+  });
+
+  it('should check violated rule - windows prevention', () => {
+    const validatedPath = isValidWindowsFileName('CON.log');
+
+    expect(validatedPath).toBe(false);
+  });
+
+  it('should check violated rule - windows invalid characters', () => {
+    const validatedPath = isValidWindowsFileName('\\.log');
+
+    expect(validatedPath).toBe(false);
+  });
+
+  it('should perform correct file copy', () => {
+    const spyCopyFileSync = spyOn(fs, 'copyFileSync');
+
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
+
+    copyOneSingleFile('C:\\abc.log', 'C:\\logs');
+
+    expect(spyCopyFileSync).toBeCalledWith('C:\\abc.log', 'C:\\logs');
+  });
+
+  it('should perform correct file copy', () => {
+    const spyCopyFileSync = spyOn(fs, 'copyFileSync');
+
+    jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
+
+    copyOneSingleFile('C:\\abc.log', 'C:\\logs');
+
+    expect(spyCopyFileSync).toBeCalledWith('C:\\abc.log', 'C:\\logs');
+  });
+
+  it('should perform correct file copy via read and write method', () => {
+    const spyCopyFileSync = spyOn(fs, 'writeFileSync');
+
+    jest
+      .spyOn(fs, 'readFileSync')
+      .mockImplementation((sourcePath: string) => sourcePath);
+
+    copyFileUsingReadWrite('C:\\abc.log', 'C:\\logs');
+
+    expect(spyCopyFileSync).toBeCalledWith('C:\\logs', 'C:\\abc.log');
+  });
+
+  it('should perform correct file copy via copyFiles', () => {
+    const spyReaddir = jest.spyOn(fs, 'readdir');
+
+    jest
+      .spyOn(fs, 'existsSync')
+      .mockImplementation((sourcePath: string) => !!sourcePath);
+
+    copyFiles('C:\\abc.log', 'C:\\logs', []);
+
+    expect(spyReaddir).toBeCalledWith('C:\\abc.log', expect.any(Function));
+  });
+});

--- a/spec/helpers/files.spec.ts
+++ b/spec/helpers/files.spec.ts
@@ -1,0 +1,198 @@
+import * as fs from 'fs';
+import { Files } from '../../src/app/helpers/file/files';
+import {
+  LogCategory,
+  Platform,
+} from '../../src/app/interfaces/reports-handlers.interface';
+import { IFile } from '../../src/app/interfaces/file.interface';
+import { isLinux, isMac } from '../../src/common/env';
+
+describe('files', () => {
+  let file = new Files();
+  let folderPath = 'C:\\abc';
+  let fsMock;
+  let logs = [
+    'C9Zeus.2529612.log',
+    'C9Zeus.1.log',
+    'C9Trader.25296.log',
+    'C9Trader.25.log',
+    'HEHE.txt',
+    'HAH.txt',
+  ];
+  beforeEach(() => {
+    fsMock = jest.spyOn(fs, 'readdirSync').mockImplementation(() => logs);
+  });
+
+  afterEach(() => {
+    fsMock.mockRestore();
+  });
+
+  it('should return enough files in folder', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    const files = file.retrieveFilesInFolders(folderPath, {
+      includeOnly: [
+        LogCategory.C9_TRADER,
+        LogCategory.C9_ZUES,
+        LogCategory.CLIENT,
+      ],
+    });
+
+    expect(files).toStrictEqual([
+      'C9Zeus.2529612.log',
+      'C9Zeus.1.log',
+      'C9Trader.25296.log',
+      'C9Trader.25.log',
+    ]);
+  });
+  it('should return enough logs in folder - old modified', () => {
+    const stats = {
+      dev: 2114,
+      ino: 48064969,
+      mode: 33188,
+      nlink: 1,
+      uid: 85,
+      gid: 100,
+      rdev: 0,
+      size: 527,
+      blksize: 4096,
+      blocks: 8,
+      atimeMs: 1318289051000.1,
+      mtimeMs: 1318289051000.1,
+      ctimeMs: 1318289051000.1,
+      birthtimeMs: 1318289051000.1,
+      atime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      mtime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      ctime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      birthtime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      isFile: () => true,
+    };
+    const now = new Date();
+
+    jest.spyOn(fs, 'statSync').mockImplementation((path) => {
+      switch (path) {
+        case `${folderPath}\\${logs[0]}`: {
+          const newStats = { ...stats };
+          newStats.mtime = new Date(now.getTime() - 360 * 60 * 1000);
+          return newStats;
+        }
+        case `${folderPath}\\${logs[2]}`: {
+          const newStats = { ...stats };
+          newStats.mtime = new Date(now.getTime() - 380 * 60 * 1000);
+          return stats;
+        }
+        default: {
+          return stats;
+        }
+      }
+    });
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const files = file.getLatestModifiedFiles(folderPath, {
+      includeOnly: [
+        LogCategory.C9_TRADER,
+        LogCategory.C9_ZUES,
+        LogCategory.CLIENT,
+      ],
+      type: Platform.IV,
+    });
+    const firstModifiedFile: IFile = {
+      fileName: logs[0],
+      platform: Platform.IV,
+      modifiedTimestamp: new Date(now.getTime() - 360 * 60 * 1000).getTime(),
+      path: 'C:\\abc\\' + logs[0],
+    };
+
+    if (isLinux || isMac) {
+      expect(files?.get(LogCategory.RECENT)).toEqual(undefined);
+    } else {
+      expect(files?.get(LogCategory.RECENT)).toEqual(firstModifiedFile);
+    }
+  });
+
+  it('should return enough logs in folder - mixed modified but get latest ones', () => {
+    const stats = {
+      dev: 2114,
+      ino: 48064969,
+      mode: 33188,
+      nlink: 1,
+      uid: 85,
+      gid: 100,
+      rdev: 0,
+      size: 527,
+      blksize: 4096,
+      blocks: 8,
+      atimeMs: 1318289051000.1,
+      mtimeMs: 1318289051000.1,
+      ctimeMs: 1318289051000.1,
+      birthtimeMs: 1318289051000.1,
+      atime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      mtime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      ctime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      birthtime: new Date('Mon, 10 Oct 2011 23:24:11 GMT'),
+      isFile: () => true,
+    };
+    const now = new Date();
+
+    jest.spyOn(fs, 'statSync').mockImplementation((path) => {
+      switch (path) {
+        case `${folderPath}\\${logs[0]}`: {
+          const newStats = { ...stats };
+          newStats.mtime = new Date(now.getTime() - 15 * 60 * 1000);
+          return newStats;
+        }
+        case `${folderPath}\\${logs[2]}`: {
+          const newStats = { ...stats };
+          newStats.mtime = new Date(now.getTime() - 15 * 60 * 1000);
+          return newStats;
+        }
+        case `${folderPath}\\${logs[3]}`: {
+          const newStats = { ...stats };
+          newStats.mtime = new Date(now.getTime() - 380 * 60 * 1000);
+          return newStats;
+        }
+        default: {
+          return stats;
+        }
+      }
+    });
+
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+    const files = file.getLatestModifiedFiles(folderPath, {
+      includeOnly: [
+        LogCategory.C9_TRADER,
+        LogCategory.C9_ZUES,
+        LogCategory.CLIENT,
+      ],
+      type: Platform.IV,
+    });
+    const result = new Map<string, IFile>();
+    const firstModifiedFile: IFile = {
+      fileName: logs[0],
+      platform: Platform.IV,
+      modifiedTimestamp: new Date(now.getTime() - 15 * 60 * 1000).getTime(),
+      path: 'C:\\abc\\' + logs[0],
+    };
+    const secondModifiedFile: IFile = {
+      fileName: logs[2],
+      platform: Platform.IV,
+      modifiedTimestamp: new Date(now.getTime() - 15 * 60 * 1000).getTime(),
+      path: 'C:\\abc\\' + logs[2],
+    };
+
+    result.set(LogCategory.LATEST + '_0', firstModifiedFile);
+    result.set(LogCategory.LATEST + '_2', secondModifiedFile);
+
+    if (isLinux || isMac) {
+      expect(files?.get(LogCategory.LATEST + '_0')).toEqual(undefined);
+      expect(files?.get(LogCategory.LATEST + '_2')).toEqual(undefined);
+    } else {
+      expect(files?.get(LogCategory.LATEST + '_' + logs[0])).toEqual(
+        firstModifiedFile,
+      );
+      expect(files?.get(LogCategory.LATEST + '_' + logs[2])).toEqual(
+        secondModifiedFile,
+      );
+    }
+  });
+});

--- a/src/app/helpers/file/files-factory.ts
+++ b/src/app/helpers/file/files-factory.ts
@@ -1,0 +1,12 @@
+import { Files } from './files';
+
+export class FilesFactory {
+  /**
+   * Generating a new instance of Files
+   *
+   * @return new instance of Files
+   */
+  public static create() {
+    return new Files();
+  }
+}

--- a/src/app/helpers/file/files-helper.ts
+++ b/src/app/helpers/file/files-helper.ts
@@ -57,7 +57,30 @@ const copyFiles = (
 
     files.forEach((file) => {
       if (!(filterCondition.length < 1) || filterCondition.includes(file)) {
+        if (
+          !isValidWindowsFileName(file) ||
+          !isValidWindowsFilePath(sourceFolder) ||
+          !isValidWindowsFilePath(destinationFolder)
+        ) {
+          const infoFileName = `Invalid File Name - ${file}`;
+          const infoSource = `Invalid Source Folder - ${sourceFolder}`;
+          const infoDestination = `Invalid Destination Folder - ${destinationFolder}`;
+
+          logger.info(
+            `files-helper: ${
+              !isValidWindowsFileName(file)
+                ? infoFileName
+                : !isValidWindowsFilePath(sourceFolder)
+                ? infoSource
+                : infoDestination
+            }`,
+          );
+
+          return;
+        }
+        // nosemgrep
         const sourcePath = path.join(sourceFolder, file);
+        // nosemgrep
         const destinationPath = path.join(destinationFolder, file);
 
         logger.info(

--- a/src/app/helpers/file/files-helper.ts
+++ b/src/app/helpers/file/files-helper.ts
@@ -1,0 +1,118 @@
+import * as fs from 'fs';
+import path = require('path');
+import { isWindowsOS } from '../../../common/env';
+import { logger } from '../../../common/logger';
+
+const convertFileName = (filename: string): string => {
+  return filename?.replace(/[^a-zA-Z0-9/_\.-]/g, '_');
+};
+
+const isValidWindowsFileName = (filename: string): boolean => {
+  const invalidChars = /[<>:"/\\|?*\x00-\x1F]/;
+  const reservedNames = /^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\..*)?$/i;
+
+  return !invalidChars.test(filename) && !reservedNames.test(filename);
+};
+
+const isValidWindowsFilePath = (path: string) => {
+  const unixPathRegex = /^\/([^\/]+\/)*([^\/]+)$/;
+  const windowsPathRegex = /^[a-zA-Z]:\\([^\\]+\\)*([^\\]+)$/;
+
+  if (isWindowsOS) {
+    logger.info(
+      `files-helper: indicating if ${path} is a valid window path - ${windowsPathRegex.test(
+        path,
+      )}`,
+    );
+    return windowsPathRegex.test(path);
+  }
+
+  return unixPathRegex.test(path);
+};
+
+const copyFiles = (
+  sourceFolder: string,
+  destinationFolder: string,
+  filterCondition: string[] = [],
+) => {
+  if (!fs.existsSync(sourceFolder)) {
+    logger.info(`files-helper: source folder isnt existed - ${sourceFolder}`);
+    return;
+  }
+
+  if (!fs.existsSync(destinationFolder)) {
+    fs.mkdirSync(destinationFolder, { recursive: true });
+    logger.info(
+      `files-helper: destination folder does not exist, starting to create - ${destinationFolder}`,
+    );
+  }
+
+  fs.readdir(sourceFolder, (err, files) => {
+    if (err) {
+      logger.info(
+        `files-helper: source folder cannot be read - ${sourceFolder}`,
+      );
+      return;
+    }
+
+    files.forEach((file) => {
+      if (!(filterCondition.length < 1) || filterCondition.includes(file)) {
+        const sourcePath = path.join(sourceFolder, file);
+        const destinationPath = path.join(destinationFolder, file);
+
+        logger.info(
+          `files-helper: verified, file is included in filterCondition`,
+        );
+        copyOneSingleFile(sourcePath, destinationPath);
+      }
+    });
+  });
+};
+
+const copyOneSingleFile = (sourceFile: string, destinationFile: string) => {
+  if (!fs.existsSync(sourceFile)) {
+    logger.info(`files-helper: source folder isnt existed - ${sourceFile}`);
+    return;
+  }
+
+  if (!fs.existsSync(destinationFile)) {
+    fs.mkdirSync(destinationFile, { recursive: true });
+    logger.info(
+      `files-helper: destination folder does not exist, starting to create - ${destinationFile}`,
+    );
+  }
+
+  try {
+    fs.copyFileSync(sourceFile, destinationFile);
+    logger.info(`files-helper: copying ${sourceFile} to ${destinationFile}`);
+  } catch (err) {
+    logger.info(
+      `files-helper: failed in performing copy ${sourceFile} to ${destinationFile}`,
+    );
+    logger.info(`files-helper: exception - ${err}`);
+  }
+};
+
+const copyFileUsingReadWrite = (
+  sourcePath: string,
+  destinationPath: string,
+) => {
+  try {
+    const logRead = fs.readFileSync(sourcePath, 'utf8');
+    fs.writeFileSync(destinationPath, logRead);
+    logger.info(
+      `files-helper: copying file using read and write ${sourcePath} to ${destinationPath}`,
+    );
+  } catch (e) {
+    logger.info(`files-helper: insuffient permission to copy the file`);
+  }
+};
+
+export {
+  convertFileName,
+  isValidWindowsFileName,
+  isValidWindowsFilePath,
+  copyOneSingleFile,
+  copyFiles,
+  copyFileUsingReadWrite,
+};

--- a/src/app/helpers/file/files.ts
+++ b/src/app/helpers/file/files.ts
@@ -1,0 +1,135 @@
+import * as fs from 'fs';
+import path = require('path');
+import { logger } from '../../../common/logger';
+import { IFile } from '../../interfaces/file.interface';
+import {
+  LogCategory,
+  LogUtilities,
+  Platform,
+} from '../../interfaces/reports-handlers.interface';
+import { isValidWindowsFileName, isValidWindowsFilePath } from './files-helper';
+
+export class Files {
+  private files = new Map<string, IFile>();
+
+  public retrieveFilesInFolders = (
+    sourcePath: string,
+    options: {
+      includeOnly?: string[];
+      type?: string;
+    },
+  ) => {
+    if (!fs.existsSync(sourcePath)) {
+      logger.info('files-factory: folder does not exist');
+      return undefined;
+    }
+
+    const logFiles = fs.readdirSync(sourcePath);
+    logger.info(`files-factory: found ${logFiles.length} log(s)`);
+
+    return logFiles?.filter((file) => {
+      return options?.includeOnly?.some((format) =>
+        file.toLowerCase().includes(format),
+      );
+    });
+  };
+
+  /**
+   * Archives files in the source directory
+   * that matches the given file extension
+   *
+   * @param sourcePath {String} source path
+   * @param options additional options to get the files
+   * @param options.includeOnly: took value from LogCategory
+   * @param options.type: type of files
+   * @return {Promise<void>}
+   */
+  public getLatestModifiedFiles = (
+    sourcePath: string,
+    options: {
+      includeOnly?: string[];
+      type?: string;
+    },
+  ) => {
+    if (!fs.existsSync(sourcePath)) {
+      logger.info('files-factory: folder does not exist');
+      return undefined;
+    }
+
+    const logFiles = fs.readdirSync(sourcePath);
+    logger.info(`files-factory: found ${logFiles.length} log(s)`);
+    const now = new Date();
+    let latestModifiedLogTimestamp = 0;
+
+    logFiles?.forEach((file) => {
+      const isValidLogName = isValidWindowsFileName(file);
+      const isValidsourcePath = isValidWindowsFilePath(
+        path.normalize(sourcePath),
+      );
+
+      if (!isValidLogName || !isValidsourcePath) {
+        logger.info(
+          'files-factory: Malformed log path or name, log is excluded',
+        );
+        return;
+      }
+
+      const logFilePath = path.join(sourcePath, file);
+      logger.info(`files-factory: constructing ${logFilePath}`);
+
+      const logFileStats = fs.statSync(logFilePath);
+      const currentLogModifiedTimestamp = logFileStats.mtime.getTime();
+
+      if (
+        logFileStats.isFile() &&
+        file.includes('.log') &&
+        file.split('.log').filter((word) => !word).length < 2 &&
+        options?.includeOnly?.some((option) =>
+          file.toLowerCase().includes(option),
+        )
+      ) {
+        logger.info(
+          `files-factory: include only files by format - ${
+            options.includeOnly.length > 1
+              ? options.includeOnly.concat(',')
+              : options.includeOnly.length === 1
+              ? options.includeOnly
+              : 'none'
+          }`,
+        );
+
+        const logLastModifiedTimestamp = new Date(logFileStats.mtime);
+        const timestampDiffInMinutes =
+          (now.getTime() - logLastModifiedTimestamp.getTime()) /
+          LogUtilities.ONE_MINUTE;
+        const modifiedFile: IFile = {
+          fileName: file,
+          platform: options?.type ?? Platform.IV,
+          modifiedTimestamp: currentLogModifiedTimestamp,
+          path: logFilePath,
+        };
+
+        if (timestampDiffInMinutes <= LogUtilities.LOG_TIMESTAMP_THRESHOLD) {
+          logger.info(
+            `files-factory: recent log found, temporarily added as latest - ${LogCategory.LATEST}_${file}`,
+          );
+          this.files.set(`${LogCategory.LATEST}_${file}`, modifiedFile);
+          latestModifiedLogTimestamp = logFileStats.mtime.getTime();
+        } else if (currentLogModifiedTimestamp > latestModifiedLogTimestamp) {
+          logger.info(
+            `files-factory: recent log not found, temporarily added as recent - ${LogCategory.RECENT}`,
+          );
+          this.files.set(LogCategory.RECENT, modifiedFile);
+          latestModifiedLogTimestamp = currentLogModifiedTimestamp;
+        }
+      }
+    });
+
+    if (this.files.size > 1) {
+      logger.info(`files-factory: latest log found, remove recent log`);
+      this.files.delete(LogCategory.RECENT);
+    }
+
+    return this.files;
+  };
+}

--- a/src/app/interfaces/file.interface.ts
+++ b/src/app/interfaces/file.interface.ts
@@ -1,0 +1,11 @@
+export interface IFile {
+  fileName: string;
+  platform: string;
+  modifiedTimestamp: number;
+  path?: string;
+}
+
+export interface IFileOptions {
+  includeOnly?: string[];
+  type?: string;
+}

--- a/src/app/interfaces/reports-handlers.interface.ts
+++ b/src/app/interfaces/reports-handlers.interface.ts
@@ -1,0 +1,20 @@
+export enum Platform {
+  IV = 'IV',
+}
+
+export enum LogCategory {
+  LATEST = 'LATEST',
+  RECENT = 'RECENT',
+  C9_TRADER = 'c9trader',
+  C9_ZUES = 'c9zeus',
+  CLIENT = 'client_',
+}
+
+export enum LogUtilities {
+  ONE_MINUTE = 60000,
+  // Timestamp threshold, in minutes
+  LOG_TIMESTAMP_THRESHOLD = 30,
+}
+
+export type RetrieveIVLogs = () => void;
+export type RemoveIVLogs = (logsPath: string) => void;

--- a/src/app/reports-handler.ts
+++ b/src/app/reports-handler.ts
@@ -12,6 +12,7 @@ import { FilesFactory } from './helpers/file/files-factory';
 import {
   copyFileUsingReadWrite,
   isValidWindowsFileName,
+  isValidWindowsFilePath,
 } from './helpers/file/files-helper';
 import {
   LogCategory,
@@ -305,6 +306,19 @@ const removeLastIVLogs: RemoveIVLogs = (logsPath: string) => {
     `reports-handler: found ${ivLogsList?.length} old log(s) to be removed`,
   );
   ivLogsList?.forEach((log) => {
+    if (!isValidWindowsFileName(log) || !isValidWindowsFilePath(logsPath)) {
+      const infoLogName = `Invalid File Name - ${log}`;
+      const infoLogPath = `Invalid Logs Path - ${logsPath}`;
+
+      logger.info(
+        `files-helper: ${
+          !isValidWindowsFileName(log) ? infoLogName : infoLogPath
+        }`,
+      );
+
+      return;
+    }
+    // nosemgrep
     const logPath = path.join(logsPath, log);
     if (!fs.existsSync(logPath)) {
       logger.info('reports-handler: log file check, not exist');


### PR DESCRIPTION
## Description
Introducing a new way of adding IV logs into the bundle.
- This time, it will use the reader stream to avoid issues related to inaccessible location in users without consent. It will read the file in buffer then write it into the destination
- Adding a few validation related to the file thus, it will be ignored if they contain windows forbidden regex / keywords
- Adding a further logging to help understand deeply in how'd the logs behaving
## Related PRs
