### PR TITLE
RTC-15423 - Remove unused screen share methods

### DIFF
--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -102,7 +102,6 @@ jest.mock('../src/app/window-handler', () => {
       closeAllWindows: jest.fn(),
       closeWindow: jest.fn(),
       createNotificationSettingsWindow: jest.fn(),
-      createScreenPickerWindow: jest.fn(),
       createScreenSharingIndicatorWindow: jest.fn(),
       isOnline: false,
       updateVersionInfo: jest.fn(),
@@ -395,18 +394,6 @@ describe('main api handler', () => {
         windowName: 'notification',
       };
       const expectedValue = ['notification', false];
-      ipcMain.send(apiName.symphonyApi, value);
-      expect(spy).toBeCalledWith(...expectedValue);
-    });
-
-    it('should call `openScreenPickerWindow` correctly', () => {
-      const spy = jest.spyOn(windowHandler, 'createScreenPickerWindow');
-      const value = {
-        cmd: apiCmds.openScreenPickerWindow,
-        sources: [],
-        id: 3,
-      };
-      const expectedValue = [{ send: expect.any(Function) }, [], 3];
       ipcMain.send(apiName.symphonyApi, value);
       expect(spy).toBeCalledWith(...expectedValue);
     });

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -219,15 +219,6 @@ ipcMain.on(
           }
         }
         break;
-      case apiCmds.openScreenPickerWindow:
-        if (Array.isArray(arg.sources) && typeof arg.id === 'number') {
-          windowHandler.createScreenPickerWindow(
-            event.sender,
-            arg.sources,
-            arg.id,
-          );
-        }
-        break;
       case apiCmds.popupMenu: {
         const browserWin = BrowserWindow.fromWebContents(
           event.sender,
@@ -308,7 +299,6 @@ ipcMain.on(
           appStateHandler.preventDisplaySleep(arg.isInMeeting);
           if (!arg.isInMeeting) {
             displayMediaRequestHandler.closeScreenPickerWindow();
-            windowHandler.closeScreenPickerWindow();
             windowHandler.closeScreenSharingIndicator();
           }
         }
@@ -706,28 +696,6 @@ const logApiCallParams = (arg: any) => {
       logger.info(
         `main-api-handler: - ${apiCmd} - Properties: ${JSON.stringify(
           badgeDataUrlDetails,
-          null,
-          2,
-        )}`,
-      );
-      break;
-    case apiCmds.openScreenPickerWindow:
-      const sources = arg.sources.map((source: any) => {
-        return {
-          name: source.name,
-          id: source.id,
-          thumbnail: 'hidden',
-          display_id: source.display_id,
-          appIcon: source.appIcon,
-        };
-      });
-      const openScreenPickerDetails = {
-        ...arg,
-        sources,
-      };
-      logger.info(
-        `main-api-handler: - ${apiCmd} - Properties: ${JSON.stringify(
-          openScreenPickerDetails,
           null,
           2,
         )}`,

--- a/src/common/api-interface.ts
+++ b/src/common/api-interface.ts
@@ -20,7 +20,6 @@ export enum apiCmds {
   showNotificationSettings = 'show-notification-settings',
   sanitize = 'sanitize',
   bringToFront = 'bring-to-front',
-  openScreenPickerWindow = 'open-screen-picker-window',
   popupMenu = 'popup-menu',
   optimizeMemoryConsumption = 'optimize-memory-consumption',
   optimizeMemoryRegister = 'optimize-memory-register',

--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -572,7 +572,6 @@ Writes some thing to the file</textarea
       showNotificationSettings: 'show-notification-settings',
       sanitize: 'sanitize',
       bringToFront: 'bring-to-front',
-      openScreenPickerWindow: 'open-screen-picker-window',
       popupMenu: 'popup-menu',
       optimizeMemoryConsumption: 'optimize-memory-consumption',
       optimizeMemoryRegister: 'optimize-memory-register',


### PR DESCRIPTION
https://perzoinc.atlassian.net/browse/RTC-15423

I think `createScreenPickerWindow` and `closeScreenPickerWindow` are two methods left to clean up the old way of doing screen sharing.