### PR TITLE
Update badge and link path to reflect changes to the FINOS project lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![FINOS - Active](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-active.svg)](https://finosfoundation.atlassian.net/wiki/display/FINOS/Active)
+[![FINOS - Graduated](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-graduated.svg)](https://community.finos.org/docs/governance/lifecycle-stages/graduated)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6746/badge)](https://bestpractices.coreinfrastructure.org/projects/6746)
 [![Continuous Integration](https://github.com/symphonyoss/SymphonyElectron/actions/workflows/ci.yml/badge.svg)](https://github.com/symphonyoss/SymphonyElectron/actions/workflows/ci.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/symphonyoss/SymphonyElectron/badge.svg?targetFile=package.json)](https://snyk.io/test/github/symphonyoss/SymphonyElectron?targetFile=package.json)


### PR DESCRIPTION
This PR changes the active badge to the graduated badge and updates the badge link path to `/lifecycle-stages/` to reflect the new documentation structure on https://community.finos.org/docs/governance/.

The `active` stage has been renamed to `graduated` per the new FINOS project lifecycle. Please make sure to read and understand the new [FINOS project lifecycle](https://www.finos.org/blog/updated-finos-project-lifecycle) and reach out to toc@lists.finos.org if you have any questions regarding the new lifecycle.

> [!IMPORTANT]
> This PR was generated automatically. We kindly ask you to review it manually, confirm there are no other occurrences of the badge logic in other files, and merge at your earliest convenience. If you have any questions or concerns, please email help@finos.org.