### PR TITLE
SDA-5024 Toggle fullscreen menu entry workaround on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
     "cheerio": "v1.0.0-rc.12",
     "cross-env": "7.0.3",
     "del": "3.0.0",
-    "electron": "39.5.1",
+    "electron": "41.3.0",
     "electron-builder": "^26.3.1",
     "electron-devtools-installer": "^3.2.0",
     "electron-icon-maker": "0.0.5",

--- a/src/app/app-menu.ts
+++ b/src/app/app-menu.ts
@@ -400,12 +400,32 @@ export class AppMenu {
           'zoomOut',
         ),
         this.buildSeparator(),
-        this.assignRoleOrLabel({
-          role: 'togglefullscreen',
-          label: i18n.t('Toggle Full Screen')(),
-        }),
+        this.addToggleFullScreenMenuItem(),
       ],
     };
+  }
+
+  /**
+   * Creates a menu item to toggle full screen with different implementation for windows and macOS due to the difference in how full screen is handled in both OS
+   * @returns Menu item
+   */
+  private addToggleFullScreenMenuItem(): Electron.MenuItemConstructorOptions {
+    if (isWindowsOS) {
+      return this.assignRoleOrLabel({
+        role: 'togglefullscreen',
+        label: i18n.t('Toggle Full Screen')(),
+      });
+    } else {
+      return {
+        label: i18n.t('Toggle Full Screen')(),
+        accelerator: 'Ctrl+Command+F',
+        click: (_item, focusedWindow) => {
+          if (focusedWindow) {
+            focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+          }
+        },
+      };
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

Duplicated menu entry workaround on macOS
