### PR TITLE
SDA-5364 - Fix argument injection / Workaround for H1 #3770918

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       "allowToChangeInstallationDirectory": false,
       "allowElevation": false,
       "include": "build/installer.nsh",
-      "uninstallDisplayName": "${productName}"
+      "uninstallDisplayName": "${productName}",
+      "publisherName": "Symphony Communication Services LLC"
     },
     "files": [
       "!.git${/*}",

--- a/spec/chromeFlags.spec.ts
+++ b/spec/chromeFlags.spec.ts
@@ -1,4 +1,4 @@
-import { setChromeFlags } from '../src/app/chrome-flags';
+import { isSafeAuthWhitelist, setChromeFlags } from '../src/app/chrome-flags';
 import { config } from '../src/app/config-handler';
 import { isDevEnv, isLinux, isMac, isWindowsOS } from '../src/common/env';
 import { app } from './__mocks__/electron';
@@ -65,22 +65,22 @@ describe('chrome flags', () => {
   it('should call `setChromeFlags` correctly', () => {
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
+    expect(spy).nthCalledWith(1, 'disable-background-timer-throttling', 'true');
+    expect(spy).nthCalledWith(2, 'disable-d3d11', true);
+    expect(spy).nthCalledWith(3, 'disable-gpu', true);
+    expect(spy).nthCalledWith(4, 'disable-gpu-compositing', true);
     expect(spy).nthCalledWith(
-      1,
-      'auth-negotiate-delegate-whitelist',
-      'whitelist',
-    );
-    expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'url');
-    expect(spy).nthCalledWith(3, 'disable-background-timer-throttling', 'true');
-    expect(spy).nthCalledWith(4, 'disable-d3d11', true);
-    expect(spy).nthCalledWith(5, 'disable-gpu', true);
-    expect(spy).nthCalledWith(6, 'disable-gpu-compositing', true);
-    expect(spy).nthCalledWith(
-      7,
+      5,
       'enable-blink-features',
       'RTCInsertableStreams',
     );
-    expect(spy).nthCalledWith(8, 'disable-features', 'ChromeRootStoreUsed');
+    expect(spy).nthCalledWith(6, 'disable-features', 'ChromeRootStoreUsed');
+    expect(spy).nthCalledWith(
+      7,
+      'auth-negotiate-delegate-whitelist',
+      'whitelist',
+    );
+    expect(spy).nthCalledWith(8, 'auth-server-whitelist', 'url');
   });
 
   it('should call `setChromeFlags` correctly when `disableGpu` is false', () => {
@@ -94,14 +94,19 @@ describe('chrome flags', () => {
     });
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
+    expect(spy).nthCalledWith(1, 'disable-background-timer-throttling', 'true');
     expect(spy).nthCalledWith(
-      1,
+      2,
+      'enable-blink-features',
+      'RTCInsertableStreams',
+    );
+    expect(spy).nthCalledWith(3, 'disable-features', 'ChromeRootStoreUsed');
+    expect(spy).nthCalledWith(
+      4,
       'auth-negotiate-delegate-whitelist',
       'whitelist',
     );
-    expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'url');
-    expect(spy).nthCalledWith(3, 'disable-background-timer-throttling', 'true');
-    expect(spy).not.nthCalledWith(4);
+    expect(spy).nthCalledWith(5, 'auth-server-whitelist', 'url');
   });
 
   it('should set `disable-renderer-backgrounding` chrome flag correctly when cloud config is ENABLED', () => {
@@ -117,8 +122,7 @@ describe('chrome flags', () => {
     });
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
-    expect(spy).nthCalledWith(7, 'disable-renderer-backgrounding', 'true');
-    expect(spy).not.nthCalledWith(8);
+    expect(spy).toHaveBeenCalledWith('disable-renderer-backgrounding', 'true');
   });
 
   it('should set `disable-renderer-backgrounding` chrome flag correctly when cloud config PMP setting is ENABLED', () => {
@@ -129,8 +133,7 @@ describe('chrome flags', () => {
     });
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
-    expect(spy).nthCalledWith(9, 'disable-renderer-backgrounding', 'true');
-    expect(spy).not.nthCalledWith(10);
+    expect(spy).toHaveBeenCalledWith('disable-renderer-backgrounding', 'true');
   });
 
   it('should set `disable-renderer-backgrounding` chrome flag when any one is ENABLED ', () => {
@@ -151,8 +154,7 @@ describe('chrome flags', () => {
     });
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
-    expect(spy).nthCalledWith(7, 'disable-renderer-backgrounding', 'true');
-    expect(spy).not.nthCalledWith(8);
+    expect(spy).toHaveBeenCalledWith('disable-renderer-backgrounding', 'true');
   });
 
   it('should set `disable-renderer-backgrounding` chrome flag when PMP is ENABLED', () => {
@@ -173,8 +175,7 @@ describe('chrome flags', () => {
     });
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
-    expect(spy).nthCalledWith(7, 'disable-renderer-backgrounding', 'true');
-    expect(spy).not.nthCalledWith(8);
+    expect(spy).toHaveBeenCalledWith('disable-renderer-backgrounding', 'true');
   });
 
   describe('`isDevEnv`', () => {
@@ -187,18 +188,108 @@ describe('chrome flags', () => {
       setChromeFlags();
       expect(spy).nthCalledWith(
         1,
-        'auth-negotiate-delegate-whitelist',
-        'whitelist',
-      );
-      expect(spy).nthCalledWith(2, 'auth-server-whitelist', 'url');
-      expect(spy).nthCalledWith(
-        3,
         'disable-background-timer-throttling',
         'true',
       );
-      expect(spy).nthCalledWith(4, 'disable-d3d11', true);
-      expect(spy).nthCalledWith(5, 'disable-gpu', true);
-      expect(spy).nthCalledWith(6, 'disable-gpu-compositing', true);
+      expect(spy).nthCalledWith(2, 'disable-d3d11', true);
+      expect(spy).nthCalledWith(3, 'disable-gpu', true);
+      expect(spy).nthCalledWith(4, 'disable-gpu-compositing', true);
+      expect(spy).nthCalledWith(
+        7,
+        'auth-negotiate-delegate-whitelist',
+        'whitelist',
+      );
+      expect(spy).nthCalledWith(8, 'auth-server-whitelist', 'url');
     });
+  });
+
+  describe('auth whitelist validation (H1 #3770918 residual)', () => {
+    const authNegotiateFlag = 'auth-negotiate-delegate-whitelist';
+    const authServerFlag = 'auth-server-whitelist';
+
+    it('rejects bare `*` wildcard in authServerWhitelist', () => {
+      config.getConfigFields = jest.fn(() => ({
+        customFlags: {
+          authServerWhitelist: '*',
+          authNegotiateDelegateWhitelist: '',
+        },
+      }));
+      const spy = jest.spyOn(app.commandLine, 'appendSwitch');
+      setChromeFlags();
+      expect(spy).not.toHaveBeenCalledWith(authServerFlag, '*');
+      expect(spy).not.toHaveBeenCalledWith(
+        authNegotiateFlag,
+        expect.anything(),
+      );
+    });
+
+    it('rejects `*` as an entry inside a comma-separated authServerWhitelist', () => {
+      config.getConfigFields = jest.fn(() => ({
+        customFlags: {
+          authServerWhitelist: '*.symphony.com,*',
+          authNegotiateDelegateWhitelist: '',
+        },
+      }));
+      const spy = jest.spyOn(app.commandLine, 'appendSwitch');
+      setChromeFlags();
+      expect(spy).not.toHaveBeenCalledWith(
+        authServerFlag,
+        expect.stringContaining('*.symphony.com,*'),
+      );
+    });
+
+    it('rejects bare `*` in authNegotiateDelegateWhitelist', () => {
+      config.getConfigFields = jest.fn(() => ({
+        customFlags: {
+          authServerWhitelist: '',
+          authNegotiateDelegateWhitelist: '*',
+        },
+      }));
+      const spy = jest.spyOn(app.commandLine, 'appendSwitch');
+      setChromeFlags();
+      expect(spy).not.toHaveBeenCalledWith(authNegotiateFlag, '*');
+    });
+
+    it('accepts legitimate domain-scoped whitelist values', () => {
+      config.getConfigFields = jest.fn(() => ({
+        customFlags: {
+          authServerWhitelist: '*.symphony.com,sso.corp.example',
+          authNegotiateDelegateWhitelist: 'sso.corp.example',
+        },
+      }));
+      const spy = jest.spyOn(app.commandLine, 'appendSwitch');
+      setChromeFlags();
+      expect(spy).toHaveBeenCalledWith(
+        authServerFlag,
+        '*.symphony.com,sso.corp.example',
+      );
+      expect(spy).toHaveBeenCalledWith(authNegotiateFlag, 'sso.corp.example');
+    });
+  });
+});
+
+describe('isSafeAuthWhitelist', () => {
+  it('rejects empty/missing input', () => {
+    expect(isSafeAuthWhitelist(undefined)).toBe(false);
+    expect(isSafeAuthWhitelist(null)).toBe(false);
+    expect(isSafeAuthWhitelist('')).toBe(false);
+    expect(isSafeAuthWhitelist('   ')).toBe(false);
+    expect(isSafeAuthWhitelist(123)).toBe(false);
+  });
+
+  it('rejects a bare `*` wildcard', () => {
+    expect(isSafeAuthWhitelist('*')).toBe(false);
+    expect(isSafeAuthWhitelist(' * ')).toBe(false);
+  });
+
+  it('rejects `*` as any comma-separated entry', () => {
+    expect(isSafeAuthWhitelist('*.symphony.com,*')).toBe(false);
+    expect(isSafeAuthWhitelist('*, sso.corp.example')).toBe(false);
+  });
+
+  it('accepts specific hostnames and subdomain wildcards', () => {
+    expect(isSafeAuthWhitelist('sso.corp.example')).toBe(true);
+    expect(isSafeAuthWhitelist('*.symphony.com')).toBe(true);
+    expect(isSafeAuthWhitelist('*.symphony.com, sso.corp.example')).toBe(true);
   });
 });

--- a/spec/chromeFlags.spec.ts
+++ b/spec/chromeFlags.spec.ts
@@ -95,18 +95,19 @@ describe('chrome flags', () => {
     const spy = jest.spyOn(app.commandLine, 'appendSwitch');
     setChromeFlags();
     expect(spy).nthCalledWith(1, 'disable-background-timer-throttling', 'true');
+    expect(spy).nthCalledWith(2, 'disable-d3d11', true);
     expect(spy).nthCalledWith(
-      2,
+      3,
       'enable-blink-features',
       'RTCInsertableStreams',
     );
-    expect(spy).nthCalledWith(3, 'disable-features', 'ChromeRootStoreUsed');
+    expect(spy).nthCalledWith(4, 'disable-features', 'ChromeRootStoreUsed');
     expect(spy).nthCalledWith(
-      4,
+      5,
       'auth-negotiate-delegate-whitelist',
       'whitelist',
     );
-    expect(spy).nthCalledWith(5, 'auth-server-whitelist', 'url');
+    expect(spy).nthCalledWith(6, 'auth-server-whitelist', 'url');
   });
 
   it('should set `disable-renderer-backgrounding` chrome flag correctly when cloud config is ENABLED', () => {

--- a/spec/mainApiHandler.spec.ts
+++ b/spec/mainApiHandler.spec.ts
@@ -118,6 +118,7 @@ jest.mock('../src/app/window-utils', () => {
   return {
     downloadManagerAction: jest.fn(),
     getWindowByName: jest.fn(),
+    isTrustedSenderFrame: jest.fn(() => true),
     isValidWindow: jest.fn(() => true),
     isValidView: jest.fn(),
     sanitize: jest.fn(),

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -23,6 +23,8 @@ const specialArgs = [
   '--inspect',
   '--logPath',
   '--custom-timezone',
+  '--auth-server-whitelist',
+  '--auth-negotiate-delegate-whitelist',
 ];
 
 /**
@@ -78,14 +80,20 @@ export const setChromeFlags = () => {
     const splittedChromeFlags = chromeFlagsSplitter(chromeFlags);
     cmdArgs = cmdArgs.concat(splittedChromeFlags);
   }
-  cmdArgs.forEach((arg) => {
+  for (const arg of cmdArgs) {
+    // Stop processing at the `--` separator: anything after it is positional
+    // (the symphony:// URI placed by the protocol handler) and must never be
+    // promoted to a Chromium switch (H1 #3770918).
+    if (arg === '--') {
+      break;
+    }
     // We need to check if the argument key matches the one
     // in the special args array and return if it does match
     const argSplit = arg.split('=');
     const argKey = argSplit[0];
     const argValue = argSplit[1] && arg.substring(arg.indexOf('=') + 1);
     if (arg.startsWith(CHROME_FLAG_PREFIX) && specialArgs.includes(argKey)) {
-      return;
+      continue;
     }
 
     // All the chrome flags starts with --
@@ -107,7 +115,7 @@ export const setChromeFlags = () => {
         );
       }
     }
-  });
+  }
 };
 
 /**

--- a/src/app/chrome-flags.ts
+++ b/src/app/chrome-flags.ts
@@ -28,6 +28,24 @@ const specialArgs = [
 ];
 
 /**
+ * Validates an --auth-server-whitelist / --auth-negotiate-delegate-whitelist
+ * value before it is applied as a Chromium switch or NTLM-credential allowlist.
+ */
+export const isSafeAuthWhitelist = (value: unknown): value is string => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const entries = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (entries.length === 0) {
+    return false;
+  }
+  return entries.every((entry) => entry !== '*');
+};
+
+/**
  * Sets chrome flags
  */
 export const setChromeFlags = () => {
@@ -41,9 +59,6 @@ export const setChromeFlags = () => {
     'disableThrottling',
   ]) as any;
   const configFlags: object = {
-    'auth-negotiate-delegate-whitelist':
-      flagsConfig.customFlags.authNegotiateDelegateWhitelist,
-    'auth-server-whitelist': flagsConfig.customFlags.authServerWhitelist,
     'disable-background-timer-throttling': 'true',
     'disable-d3d11': true,
     'disable-gpu': flagsConfig.disableGpu || null,
@@ -51,6 +66,20 @@ export const setChromeFlags = () => {
     'enable-blink-features': 'RTCInsertableStreams',
     'disable-features': 'ChromeRootStoreUsed',
   };
+  const authNegotiate = flagsConfig.customFlags?.authNegotiateDelegateWhitelist;
+  if (isSafeAuthWhitelist(authNegotiate)) {
+    configFlags['auth-negotiate-delegate-whitelist'] = authNegotiate;
+  } else if (authNegotiate) {
+    logger.warn(
+      `chrome-flags: rejecting unsafe authNegotiateDelegateWhitelist value`,
+    );
+  }
+  const authServer = flagsConfig.customFlags?.authServerWhitelist;
+  if (isSafeAuthWhitelist(authServer)) {
+    configFlags['auth-server-whitelist'] = authServer;
+  } else if (authServer) {
+    logger.warn(`chrome-flags: rejecting unsafe authServerWhitelist value`);
+  }
   if (
     flagsConfig.customFlags.disableThrottling ===
       CloudConfigDataTypes.ENABLED ||
@@ -129,11 +158,14 @@ export const setSessionProperties = () => {
   if (
     defaultSession &&
     customFlags &&
-    customFlags.authServerWhitelist &&
-    customFlags.authServerWhitelist !== ''
+    isSafeAuthWhitelist(customFlags.authServerWhitelist)
   ) {
     defaultSession.allowNTLMCredentialsForDomains(
       customFlags.authServerWhitelist,
+    );
+  } else if (customFlags?.authServerWhitelist) {
+    logger.warn(
+      `chrome-flags: rejecting unsafe NTLM domain allowlist from customFlags`,
     );
   }
 };

--- a/src/app/main-api-handler.ts
+++ b/src/app/main-api-handler.ts
@@ -44,6 +44,7 @@ import { ICustomBrowserWindow, windowHandler } from './window-handler';
 import {
   downloadManagerAction,
   getWindowByName,
+  isTrustedSenderFrame,
   isValidView,
   isValidWindow,
   sanitize,
@@ -118,12 +119,13 @@ ipcMain.on(
   async (event: Electron.IpcMainEvent, arg: IApiArgs) => {
     if (
       !(
-        isValidWindow(BrowserWindow.fromWebContents(event.sender)) ||
-        isValidView(event.sender)
+        (isValidWindow(BrowserWindow.fromWebContents(event.sender)) ||
+          isValidView(event.sender)) &&
+        isTrustedSenderFrame(event)
       )
     ) {
       logger.error(
-        `main-api-handler: invalid window try to perform action, ignoring action`,
+        `main-api-handler: invalid/untrusted window try to perform action, ignoring action`,
         arg.cmd,
       );
       return;
@@ -558,12 +560,13 @@ ipcMain.handle(
   async (event: Electron.IpcMainInvokeEvent, arg: IApiArgs) => {
     if (
       !(
-        isValidWindow(BrowserWindow.fromWebContents(event.sender)) ||
-        isValidView(event.sender)
+        (isValidWindow(BrowserWindow.fromWebContents(event.sender)) ||
+          isValidView(event.sender)) &&
+        isTrustedSenderFrame(event)
       )
     ) {
       logger.error(
-        `main-api-handler: invalid window try to perform action, ignoring action`,
+        `main-api-handler: invalid/untrusted window try to perform action, ignoring action`,
         arg.cmd,
       );
       return;

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -134,13 +134,17 @@ handlePerformanceSettings();
 setChromeFlags();
 
 // Electron sets the default protocol
+// The trailing "--" terminator forces Chromium to treat the URI (%1) as a
+// positional argument, so quote-breakout in a malicious URI cannot inject
+// switches into the SDA process (H1 #3770918).
 if (!isDevEnv) {
   const { userDataPath } = config.getConfigFields(['userDataPath']);
   if (userDataPath === '') {
-    app.setAsDefaultProtocolClient('symphony');
+    app.setAsDefaultProtocolClient('symphony', process.execPath, ['--']);
   } else {
     app.setAsDefaultProtocolClient('symphony', process.execPath, [
       '--userDataPath="' + userDataPath + '"',
+      '--',
     ]);
   }
 }

--- a/src/app/reports-handler.ts
+++ b/src/app/reports-handler.ts
@@ -38,14 +38,20 @@ const validateFilename = (filename: string): string => {
  * `baseDir`. Returns the resolved path on success, or null on traversal.
  */
 const resolveInside = (baseDir: string, filename: string): string | null => {
+  // nosemgrep
   const resolvedBase = path.resolve(baseDir);
-  const resolved = path.resolve(path.join(resolvedBase, filename));
+  const safeFilename = path
+    .normalize(filename)
+    .replace(/^(\.\.(\/|\\|$))+/, '');
+  // nosemgrep
+  const resolved = path.resolve(resolvedBase, safeFilename);
   if (
-    resolved !== resolvedBase &&
-    !resolved.startsWith(resolvedBase + path.sep)
+    !resolved.startsWith(resolvedBase + path.sep) &&
+    resolved !== resolvedBase
   ) {
     return null;
   }
+
   return resolved;
 };
 

--- a/src/app/reports-handler.ts
+++ b/src/app/reports-handler.ts
@@ -18,6 +18,37 @@ import { logger } from '../common/logger';
  * @param retrievedLogs {Array} array of client logs
  * @return {Promise<void>}
  */
+/**
+ * Sanitizes an attacker-influenced filename:
+ *   1. Strips everything outside [A-Za-z0-9_.-] (notably drops `/` and `\`,
+ *      which the previous allow-list permitted and which combined with
+ *      `path.join` enabled directory traversal — H1 #3770918 Chain A).
+ *   2. Runs `path.basename` as belt-and-braces against `..` constructs.
+ */
+const validateFilename = (filename: string): string => {
+  if (!filename) {
+    return '';
+  }
+  const stripped = filename.replace(/[^a-zA-Z0-9_\.-]/g, '_');
+  return path.basename(stripped);
+};
+
+/**
+ * Resolves `filename` inside `baseDir` and confirms the result stays inside
+ * `baseDir`. Returns the resolved path on success, or null on traversal.
+ */
+const resolveInside = (baseDir: string, filename: string): string | null => {
+  const resolvedBase = path.resolve(baseDir);
+  const resolved = path.resolve(path.join(resolvedBase, filename));
+  if (
+    resolved !== resolvedBase &&
+    !resolved.startsWith(resolvedBase + path.sep)
+  ) {
+    return null;
+  }
+  return resolved;
+};
+
 const generateArchiveForDirectory = (
   source: string,
   destination: string,
@@ -46,7 +77,17 @@ const generateArchiveForDirectory = (
 
   for (const logs of retrievedLogs) {
     for (const logFile of logs.logFiles) {
-      const file = path.join(source, logFile.filename);
+      const sanitizedFilename = validateFilename(logFile.filename);
+      if (!sanitizedFilename) {
+        continue;
+      }
+      const file = resolveInside(source, sanitizedFilename);
+      if (!file) {
+        logger.warn(
+          `reports-handler: rejecting out-of-bounds archive filename ${logFile.filename}`,
+        );
+        continue;
+      }
       archive.addLocalFile(file, 'logs');
       filesForCleanup.push(file);
     }
@@ -65,19 +106,21 @@ let logWebContents: WebContents;
 const logTypes: string[] = [];
 const receivedLogs: ILogs[] = [];
 
-const validateFilename = (filename: string): string => {
-  return filename?.replace(/[^a-zA-Z0-9/_\.-]/g, '_');
-};
-
 const writeClientLogs = async (retrievedLogs: ILogs[]) => {
+  const logsDir = app.getPath('logs');
   for await (const logs of retrievedLogs) {
     for (const logFile of logs.logFiles) {
       const sanitizedFilename = validateFilename(logFile.filename);
       if (!sanitizedFilename) {
         continue;
       }
-      // nosemgrep
-      const file = path.join(app.getPath('logs'), sanitizedFilename);
+      const file = resolveInside(logsDir, sanitizedFilename);
+      if (!file) {
+        logger.warn(
+          `reports-handler: rejecting out-of-bounds log filename ${logFile.filename}`,
+        );
+        continue;
+      }
       await writeDataToFile(file, logFile.contents);
     }
   }

--- a/src/app/voice-handler.ts
+++ b/src/app/voice-handler.ts
@@ -122,7 +122,7 @@ class VoiceHandler {
       await symCommandRegKey.set(
         '',
         Registry.REG_SZ,
-        `"${appPath}" "%1"`,
+        `"${appPath}" "--" "%1"`,
         errorCallback,
       );
       await symAppRegistrationRegKey.set(

--- a/src/app/window-handler.ts
+++ b/src/app/window-handler.ts
@@ -298,6 +298,39 @@ export class WindowHandler {
       this.shouldShowWelcomeScreen = true;
     }
 
+    // Resolve the pod URL BEFORE constructing the BrowserWindow so we can pass
+    // it as a preload additionalArgument. The preload uses this to gate
+    // contextBridge exposure to the configured pod origin only (H1 #3770918).
+    this.url = WindowHandler.getValidUrl(
+      this.userConfig.url ? this.userConfig.url : this.globalConfig.url,
+    );
+    logger.info(`window-handler: setting url ${this.url} from config file!`);
+
+    if (urlFromCmd) {
+      const commandLineUrl = urlFromCmd.substr(6);
+      logger.info(
+        `window-handler: trying to set url ${commandLineUrl} from command line.`,
+      );
+      const { podWhitelist } = config.getConfigFields(['podWhitelist']);
+      // Fail-closed: only accept --url= when an explicit, matching entry
+      // exists in podWhitelist. An empty whitelist no longer permits arbitrary
+      // URL overrides - expect for dev environment.
+      if (
+        (podWhitelist.length > 0 && podWhitelist.includes(commandLineUrl)) ||
+        isDevEnv
+      ) {
+        logger.info(
+          `window-handler: url ${commandLineUrl} from command line is whitelisted; applying override.`,
+        );
+        this.cmdUrl = commandLineUrl;
+        this.url = commandLineUrl;
+      } else {
+        logger.warn(
+          `window-handler: rejecting --url=${commandLineUrl} (podWhitelist empty or non-matching)`,
+        );
+      }
+    }
+
     this.windowOpts = {
       ...this.getWindowOpts(
         {
@@ -314,6 +347,7 @@ export class WindowHandler {
         },
         {
           preload: path.join(__dirname, '../renderer/_preload-main.js'),
+          additionalArguments: ['--initial-url=' + this.url],
         },
       ),
       ...this.opts,
@@ -342,11 +376,6 @@ export class WindowHandler {
     const { isFullScreen, isMaximized } = this.config.mainWinPos
       ? this.config.mainWinPos
       : { isFullScreen: false, isMaximized: false };
-
-    this.url = WindowHandler.getValidUrl(
-      this.userConfig.url ? this.userConfig.url : this.globalConfig.url,
-    );
-    logger.info(`window-handler: setting url ${this.url} from config file!`);
 
     // set window opts with additional config
     this.mainWindow = new BrowserWindow({
@@ -380,40 +409,6 @@ export class WindowHandler {
     );
 
     this.mainWindow.winName = apiName.mainWindowName;
-
-    if (urlFromCmd) {
-      const commandLineUrl = urlFromCmd.substr(6);
-      logger.info(
-        `window-handler: trying to set url ${commandLineUrl} from command line.`,
-      );
-      const { podWhitelist } = config.getConfigFields(['podWhitelist']);
-      logger.info(`window-handler: checking pod whitelist.`);
-      if (podWhitelist.length > 0) {
-        logger.info(
-          `window-handler: pod whitelist is not empty ${podWhitelist}`,
-        );
-        if (podWhitelist.includes(commandLineUrl)) {
-          logger.info(
-            `window-handler: url from command line is whitelisted in the config file.`,
-          );
-          logger.info(
-            `window-handler: setting ${commandLineUrl} from the command line as the main window url.`,
-          );
-          this.cmdUrl = commandLineUrl;
-          this.url = commandLineUrl;
-        } else {
-          logger.info(
-            `window-handler: url ${commandLineUrl} from command line is NOT WHITELISTED in the config file.`,
-          );
-        }
-      } else {
-        logger.info(
-          `window-handler: setting ${commandLineUrl} from the command line as the main window url since pod whitelist is empty.`,
-        );
-        this.cmdUrl = commandLineUrl;
-        this.url = commandLineUrl;
-      }
-    }
 
     // start the application maximized - for automation tests
     const isMaximizedFlag = getCommandLineArgs(

--- a/src/app/window-utils.ts
+++ b/src/app/window-utils.ts
@@ -453,6 +453,49 @@ export const isValidView = (webContents: WebContents): boolean => {
 };
 
 /**
+ * Verifies that the IPC sender frame is either an internal SDA page
+ * (file:// or about:blank) or matches the configured pod origin / whitelist.
+ */
+export const isTrustedSenderFrame = (
+  event: Electron.IpcMainEvent | Electron.IpcMainInvokeEvent,
+): boolean => {
+  if (!checkValidWindow) {
+    return true;
+  }
+  const frameUrl = event.senderFrame?.url;
+  if (!frameUrl) {
+    return false;
+  }
+
+  // Internal SDA pages are loaded from disk and are always trusted.
+  if (frameUrl.startsWith('file://') || frameUrl === 'about:blank') {
+    return true;
+  }
+
+  const mainWindow =
+    windowHandler.getMainWindow() as ICustomBrowserWindow | null;
+  const podUrl = mainWindow?.origin;
+  if (podUrl) {
+    try {
+      if (new URL(frameUrl).origin === new URL(podUrl).origin) {
+        return true;
+      }
+    } catch {
+      // fall through to whitelist check
+    }
+  }
+
+  if (whitelistHandler.isWhitelisted(frameUrl)) {
+    return true;
+  }
+
+  logger.warn(
+    `window-utils: rejecting IPC from untrusted senderFrame ${frameUrl}`,
+  );
+  return false;
+};
+
+/**
  * Updates the locale and rebuilds the entire application menu
  *
  * @param locale {LocaleType}

--- a/src/renderer/preload-main.ts
+++ b/src/renderer/preload-main.ts
@@ -22,6 +22,32 @@ const maxMemoryFetchInterval = 12 * 60 * 60 * 1000;
 const snackBar = new SnackBar();
 const banner = new MessageBanner();
 
+// Trusted pod origin injected by the main process via
+// webPreferences.additionalArguments (see window-handler.ts). Used to gate
+// contextBridge exposure to the configured pod only (H1 #3770918).
+const INITIAL_URL_PREFIX = '--initial-url=';
+const trustedInitialUrl = process.argv
+  .find((arg) => arg.startsWith(INITIAL_URL_PREFIX))
+  ?.slice(INITIAL_URL_PREFIX.length);
+
+const isTrustedOrigin = (): boolean => {
+  // Internal SDA pages (welcome, network-error, etc.) load via file:// and
+  // legitimately need API access.
+  if (window.location.protocol === 'file:') {
+    return true;
+  }
+  if (!trustedInitialUrl) {
+    return false;
+  }
+  try {
+    return (
+      new URL(window.location.href).origin === new URL(trustedInitialUrl).origin
+    );
+  } catch {
+    return false;
+  }
+};
+
 /**
  * creates API exposed from electron.
  */
@@ -29,6 +55,13 @@ const createAPI = () => {
   // iframes (and any other non-top level frames) get no api access
   // http://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t/326076
   if (window.self !== window.top) {
+    return;
+  }
+
+  // Only expose APIs when the top-level frame is the configured pod.
+  // Blocks attacker-controlled pages reached via --url= override or
+  // protocol-handler argument injection.
+  if (!isTrustedOrigin()) {
     return;
   }
 


### PR DESCRIPTION
## Description
- Fix / Workaround for H1 #3770918

### Change Summary

1. publisherName value: Must match the Subject CN on the production Authenticode cert to prevent updates from silently disabling signer verification.
2. isTrustedSenderFrame policy: Restricts to file:// + about:blank. Any internal window using DOM injection or dev-tools must use file:// or be whitelisted.
3. URL resolution reorder: Moved the this.url config/override setup to run before new BrowserWindow(...) instead of after.
4. --url= An empty podWhitelist now rejects CLI --url= overrides with a warning instead of accepting them.
5. additionalArguments propagation: Only the main window's preload context gets --initial-url=. Secondary windows (notifications, welcome, etc.) use file:// and pass isTrustedSenderFrame.
6. chrome-flags -- break: setChromeFlags passes through process.argv. Config-file chromeFlags joined via chromeFlagsSplitter cannot contain a bare -- token.
7. reports-handler.ts regex tightening: Strips / and \ from filenames, flattening subdirectory paths (e.g., mana/console.log becomes mana_console.log).

### Breaking changes
- The IPC isTrustedSenderFrame check is the most behavior-affecting change.
- `--url=` arg is breaking change for anyone whose deploy relies on podWhitelist: [] to permit CLI URL overrides. they must add explicit whitelist entries in `podWhitelist`.
- `publisherName` is set to `Symphony Communication Services LLC` and need to verify CN & autoupdate